### PR TITLE
FIX: Use upstream/main for tools

### DIFF
--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -57,13 +57,13 @@ jobs:
         run: |  # use MNE main to ensure test files are available
           set -e
           python -m pip install --upgrade pip
-          git clone -b ${MNE_BRANCH} --single-branch --depth=1 https://github.com/mne-tools/mne-python.git
+          git clone -b ${MNE_BRANCH} --single-branch --depth=1 https://github.com/mne-tools/mne-python.git ../mne-python
           python -m pip install -qe ./mne-python
           python -m pip install -ve .${PIP_OPTION} -r requirements.txt -r requirements_testing.txt
       - shell: bash -el {0}
         run: ./tools/get_testing_version.sh
         name: 'Get testing version'
-        working-directory: mne-python
+        working-directory: ../mne-python
       - uses: actions/cache@v2
         with:
           key: ${{ env.TESTING_VERSION }}
@@ -79,7 +79,7 @@ jobs:
         if: ${{ runner.os == 'Windows' && matrix.opengl != '' }}
       - run: ./tools/setup_xvfb.sh
         name: Setup xvfb on Linux
-        working-directory: mne-python
+        working-directory: ../mne-python
         if: runner.os == 'Linux'
       - name: Show system information
         run: mne sys_info

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -30,21 +30,24 @@ jobs:
         mne: [main, maint/0.24]
         opengl: ['[opengl]']
         python: ['3.9']
+        name: [matrix]
         include:
-          # old/compat
           - os: ubuntu-latest
             mne: main
             opengl: '[opengl]'
             python: '3.7'
-          # no OpenGL
+            name: old 3.7
           - os: ubuntu-latest
             mne: main
             opengl: ''
             python: '3.9'
+            name: no opengl
           - os: ubuntu-latest
             mne: maint/0.24
             opengl: ''
             python: '3.9'
+            name: no opengl
+    name: pytest ${{ matrix.name }} (${{ matrix.os }} MNE ${{ matrix.mne }})
     runs-on: ${{ matrix.os }}
     env:
       MNE_LOGGING_LEVEL: 'warning'

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -83,13 +83,13 @@ jobs:
         if: runner.os == 'Linux'
       - name: Show system information
         run: mne sys_info
-      - name: Run MNE-Tests
-        run: |
+      - run: |
           set -e
-          sed -i '/^    error::/a ignore:.*PyOpenGL was not found.*:RuntimeWarning' ./mne-python/mne/conftest.py
+          sed -i'' '/^    error::/a\    ignore:.*PyOpenGL was not found.*:RuntimeWarning' ../mne-python/mne/conftest.py
           pytest -m pgtest --cov=mne_qt_browser --cov-report=xml ./mne-python/mne/viz
-      - name: Run benchmarks
-        run: pytest mne_qt_browser/tests
+        name: Run MNE-Tests
+      - run: pytest mne_qt_browser/tests
+        name: Run benchmarks
       - uses: codecov/codecov-action@v1
         if: always()
         name: 'Upload coverage to CodeCov'

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -9,17 +9,13 @@ on:
 
 jobs:
   pytest:
-    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        include:
-        - os: [ubuntu-latest, windows-latest, macos-latest]
-        - mne: [maint/0.24, main]
-        - option: ['[opengl]', '']
-    defaults:
-      run:
-        shell: bash
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        mne: [maint/0.24, main]
+        option: ['[opengl]', '']
+    runs-on: ${{ matrix.os }}
     env:
       MNE_LOGGING_LEVEL: 'warning'
       MKL_NUM_THREADS: '1'
@@ -27,6 +23,9 @@ jobs:
       DISPLAY: ':99.0'
       MNE_BRANCH: ${{ matrix.mne }}
       PIP_OPTION: ${{ matrix.option }}
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -19,7 +19,7 @@ jobs:
         include:  # old/compat
           - os: ubuntu-latest
             mne: main
-            option: '[opengl]'
+            opengl: '[opengl]'
             python: '3.7'
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -16,7 +16,7 @@ jobs:
         include:
         - os: [ubuntu-latest, windows-latest, macos-latest]
         - mne: [maint/0.24, main]
-        - option: ['[opengl', false]
+        - option: ['[opengl]', '']
     defaults:
       run:
         shell: bash

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -18,9 +18,9 @@ jobs:
         python: ['3.9']
         include:  # old/compat
           - os: ubuntu-latest
-          - mne: main
-          - option: '[opengl]'
-          - python: '3.7'
+            mne: main
+            option: '[opengl]'
+            python: '3.7'
     runs-on: ${{ matrix.os }}
     env:
       MNE_LOGGING_LEVEL: 'warning'

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -86,7 +86,7 @@ jobs:
       - run: |
           set -e
           sed -i'' '/^    error::/a\    ignore:.*PyOpenGL was not found.*:RuntimeWarning' ../mne-python/mne/conftest.py
-          pytest -m pgtest --cov=mne_qt_browser --cov-report=xml ./mne-python/mne/viz
+          pytest -m pgtest --cov=mne_qt_browser --cov-report=xml ../mne-python/mne/viz
         name: Run MNE-Tests
       - run: pytest mne_qt_browser/tests
         name: Run benchmarks

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -15,6 +15,12 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         mne: [maint/0.24, main]
         option: ['[opengl]', '']
+        python: ['3.9']
+        include:  # old/compat
+          - os: ubuntu-latest
+          - mne: main
+          - option: '[opengl]'
+          - python: '3.7'
     runs-on: ${{ matrix.os }}
     env:
       MNE_LOGGING_LEVEL: 'warning'
@@ -23,6 +29,7 @@ jobs:
       DISPLAY: ':99.0'
       MNE_BRANCH: ${{ matrix.mne }}
       PIP_OPTION: ${{ matrix.option }}
+      PYTHON_VERSION: ${{ matrix.python }}
     defaults:
       run:
         shell: bash
@@ -31,7 +38,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies
         run: |  # use MNE main to ensure test files are available
           set -e
@@ -55,7 +62,7 @@ jobs:
           git clone --depth 1 git://github.com/pyvista/gl-ci-helpers.git
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
         name: Setup OpenGL on Windows
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' and matrix.option == '[opengl]'
       - run: ./tools/setup_xvfb.sh
         name: Setup xvfb on Linux
         working-directory: mne-python
@@ -63,12 +70,9 @@ jobs:
       - name: Show system information
         run: mne sys_info
       - name: Run MNE-Tests
-        run: |
-          set -e
-          mnePath=$(python -c "import mne; print(mne.__path__[0])")
-          echo mnePath
-          cp $mnePath/viz/tests/test_raw.py ./mne_qt_browser/tests/test_raw.py
-          pytest --cov=mne_qt_browser mne_qt_browser/tests
+        run: pytest -m pgtest --cov=mne_qt_browser --cov-report=xml ../mne-python/mne/viz/tests/test_raw.py
+      - name: Run benchmarks
+        run: pytest -sm benchmark mne_qt_browser/tests
       - uses: codecov/codecov-action@v1
         if: always()
         name: 'Upload coverage to CodeCov'

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -84,7 +84,11 @@ jobs:
       - name: Show system information
         run: mne sys_info
       - name: Run MNE-Tests
-        run: pytest -m pgtest --cov=mne_qt_browser --cov-report=xml ./mne-python/mne/viz/tests/test_raw.py
+        run: |
+          set -e
+          sed -i '/^    error::/a ignore:.*PyOpenGL was not found.*:RuntimeWarning' ./mne-python/mne/conftest.py
+          pytest -m pgtest --cov=mne_qt_browser --cov-report=xml ./mne-python/mne/viz
+        if: matrix.opengl != ''  # required until it's opt-in rather than opt-out! Until then the warning turns into an error...
       - name: Run benchmarks
         run: pytest mne_qt_browser/tests
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -88,7 +88,6 @@ jobs:
           set -e
           sed -i '/^    error::/a ignore:.*PyOpenGL was not found.*:RuntimeWarning' ./mne-python/mne/conftest.py
           pytest -m pgtest --cov=mne_qt_browser --cov-report=xml ./mne-python/mne/viz
-        if: matrix.opengl != ''  # required until it's opt-in rather than opt-out! Until then the warning turns into an error...
       - name: Run benchmarks
         run: pytest mne_qt_browser/tests
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -86,7 +86,7 @@ jobs:
           git clone --depth 1 git://github.com/pyvista/gl-ci-helpers.git
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
         name: Setup OpenGL on Windows
-        if: ${{ runner.os == 'Windows' && matrix.opengl != '' }}
+        if: runner.os == 'Windows'
       - run: ./tools/setup_xvfb.sh
         name: Setup xvfb on Linux
         working-directory: ../mne-python

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -14,9 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - os: ubuntu-latest
-        - os: windows-latest
-        - os: macos-latest
+        - os: [ubuntu-latest, windows-latest, macos-latest]
+        - mne: [maint/0.24, main]
+        - option: ['[opengl', false]
     defaults:
       run:
         shell: bash
@@ -25,6 +25,8 @@ jobs:
       MKL_NUM_THREADS: '1'
       PYTHONUNBUFFERED: '1'
       DISPLAY: ':99.0'
+      MNE_BRANCH: ${{ matrix.mne }}
+      PIP_OPTION: ${{ matrix.option }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -35,9 +37,9 @@ jobs:
         run: |  # use MNE main to ensure test files are available
           set -e
           python -m pip install --upgrade pip
-          git clone -b main --single-branch --depth=1 https://github.com/mne-tools/mne-python.git
-          python -m pip install -e .[opengl]
-          python -m pip install -r requirements.txt -r requirements_testing.txt
+          git clone -b ${MNE_BRANCH} --single-branch --depth=1 https://github.com/mne-tools/mne-python.git
+          python -m pip install -qe ./mne-python
+          python -m pip install -ve .${PIP_OPTION} -r requirements.txt -r requirements_testing.txt
       - shell: bash -el {0}
         run: ./tools/get_testing_version.sh
         name: 'Get testing version'

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -35,8 +35,8 @@ jobs:
         run: |  # use MNE main to ensure test files are available
           set -e
           python -m pip install --upgrade pip
-          git clone -b pg_test --single-branch --depth=1 https://github.com/marsipu/mne-python.git
-          python -m pip install -e ./mne-python .[opengl]
+          git clone -b main --single-branch --depth=1 https://github.com/mne-tools/mne-python.git
+          python -m pip install -e .[opengl]
           python -m pip install -r requirements.txt -r requirements_testing.txt
       - shell: bash -el {0}
         run: ./tools/get_testing_version.sh
@@ -63,7 +63,9 @@ jobs:
         run: mne sys_info
       - name: Run MNE-Tests
         run: |
+          set -e
           mnePath=$(python -c "import mne; print(mne.__path__[0])")
+          echo mnePath
           cp $mnePath/viz/tests/test_raw.py ./mne_qt_browser/tests/test_raw.py
           pytest --cov=mne_qt_browser mne_qt_browser/tests
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -62,7 +62,7 @@ jobs:
           git clone --depth 1 git://github.com/pyvista/gl-ci-helpers.git
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
         name: Setup OpenGL on Windows
-        if: runner.os == 'Windows' and matrix.option == '[opengl]'
+        if: runner.os == 'Windows'
       - run: ./tools/setup_xvfb.sh
         name: Setup xvfb on Linux
         working-directory: mne-python
@@ -70,9 +70,9 @@ jobs:
       - name: Show system information
         run: mne sys_info
       - name: Run MNE-Tests
-        run: pytest -m pgtest --cov=mne_qt_browser --cov-report=xml ../mne-python/mne/viz/tests/test_raw.py
+        run: pytest -m pgtest --cov=mne_qt_browser --cov-report=xml ./mne-python/mne/viz/tests/test_raw.py
       - name: Run benchmarks
-        run: pytest -sm benchmark mne_qt_browser/tests
+        run: pytest mne_qt_browser/tests
       - uses: codecov/codecov-action@v1
         if: always()
         name: 'Upload coverage to CodeCov'

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -8,6 +8,20 @@ on:
       branches: [main]
 
 jobs:
+  flake:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install flake8
+      - name: Lint with flake8
+        run: flake8
   pytest:
     strategy:
       fail-fast: false
@@ -76,18 +90,3 @@ jobs:
       - uses: codecov/codecov-action@v1
         if: always()
         name: 'Upload coverage to CodeCov'
-
-  flake:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install flake8
-      - name: Lint with flake8
-        run: flake8

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -27,14 +27,24 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        mne: [maint/0.24, main]
-        opengl: ['[opengl]', '']
+        mne: [main, maint/0.24]
+        opengl: ['[opengl]']
         python: ['3.9']
-        include:  # old/compat
+        include:
+          # old/compat
           - os: ubuntu-latest
             mne: main
             opengl: '[opengl]'
             python: '3.7'
+          # no OpenGL
+          - os: ubuntu-latest
+            mne: main
+            opengl: ''
+            python: '3.9'
+          - os: ubuntu-latest
+            mne: maint/0.24
+            opengl: ''
+            python: '3.9'
     runs-on: ${{ matrix.os }}
     env:
       MNE_LOGGING_LEVEL: 'warning'
@@ -83,10 +93,12 @@ jobs:
         if: runner.os == 'Linux'
       - name: Show system information
         run: mne sys_info
-      - run: |
-          set -e
-          sed -i'' '/^    error::/a\    ignore:.*PyOpenGL was not found.*:RuntimeWarning' ../mne-python/mne/conftest.py
-          pytest -m pgtest --cov=mne_qt_browser --cov-report=xml ../mne-python/mne/viz
+      # This can go away if we make OpenGL opt-in in MNE and backport the change
+      # This line also does not work on macOS
+      - run: sed -i'' '/^    error::/a\    ignore:.*PyOpenGL was not found.*:RuntimeWarning' ../mne-python/mne/conftest.py
+        name: Adjust mne conftest
+        if: matrix.opengl == ''
+      - run: pytest -m pgtest --cov=mne_qt_browser --cov-report=xml ../mne-python/mne/viz
         name: Run MNE-Tests
       - run: pytest mne_qt_browser/tests
         name: Run benchmarks

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -62,7 +62,7 @@ jobs:
           git clone --depth 1 git://github.com/pyvista/gl-ci-helpers.git
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
         name: Setup OpenGL on Windows
-        if: runner.os == 'Windows'
+        if: ${{ runner.os == 'Windows' && matrix.opengl != '' }}
       - run: ./tools/setup_xvfb.sh
         name: Setup xvfb on Linux
         working-directory: mne-python

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         mne: [maint/0.24, main]
-        option: ['[opengl]', '']
+        opengl: ['[opengl]', '']
         python: ['3.9']
         include:  # old/compat
           - os: ubuntu-latest
@@ -28,7 +28,7 @@ jobs:
       PYTHONUNBUFFERED: '1'
       DISPLAY: ':99.0'
       MNE_BRANCH: ${{ matrix.mne }}
-      PIP_OPTION: ${{ matrix.option }}
+      PIP_OPTION: ${{ matrix.opengl }}
       PYTHON_VERSION: ${{ matrix.python }}
     defaults:
       run:

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu, windows, macos]
         mne: [main, maint/0.24]
         opengl: ['[opengl]']
         python: ['3.9']
@@ -47,8 +47,8 @@ jobs:
             opengl: ''
             python: '3.9'
             name: no opengl
-    name: pytest ${{ matrix.name }} (${{ matrix.os }} MNE ${{ matrix.mne }})
-    runs-on: ${{ matrix.os }}
+    name: pytest ${{ matrix.name }} / ${{ matrix.os }} / MNE ${{ matrix.mne }}
+    runs-on: ${{ matrix.os }}-latest
     env:
       MNE_LOGGING_LEVEL: 'warning'
       MKL_NUM_THREADS: '1'

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -58,7 +58,7 @@ jobs:
           set -e
           python -m pip install --upgrade pip
           git clone -b ${MNE_BRANCH} --single-branch --depth=1 https://github.com/mne-tools/mne-python.git ../mne-python
-          python -m pip install -qe ./mne-python
+          python -m pip install -qe ../mne-python
           python -m pip install -ve .${PIP_OPTION} -r requirements.txt -r requirements_testing.txt
       - shell: bash -el {0}
         run: ./tools/get_testing_version.sh

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -32,17 +32,17 @@ jobs:
         python: ['3.9']
         name: [matrix]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu
             mne: main
             opengl: '[opengl]'
             python: '3.7'
             name: old 3.7
-          - os: ubuntu-latest
+          - os: ubuntu
             mne: main
             opengl: ''
             python: '3.9'
             name: no opengl
-          - os: ubuntu-latest
+          - os: ubuntu
             mne: maint/0.24
             opengl: ''
             python: '3.9'

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dmypy.json
 
 # PyCharm
 .idea/
+
+junit-results.xml

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include *.py
 include *.txt
 include *.yml
 recursive-include mne_qt_browser *.py
+exclude mne_qt_browser/tests/test_raw.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,3 @@ include *.py
 include *.txt
 include *.yml
 recursive-include mne_qt_browser *.py
-exclude mne_qt_browser/tests/test_raw.py

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # mne-qt-browser
+
 #### A new backend based on pyqtgraph for the 2D-Data-Browser in MNE-Python.
 
 This repository hosts the code for an alternative backend for plotting 2D-Data with 
@@ -12,6 +13,7 @@ Currently, only `Raw.plot()` is supported. For the future support for Epochs
 and ICA-Sources is planned.
 
 ### Usage
+
 Import mne-python
 ```python
 import mne
@@ -35,4 +37,18 @@ If you want to try the browser with the sample-dataset from mne-python,
 run `mne-qt-browser` from the terminal.
 
 ### Report Bugs & Feature Requests
+
 Please report bugs and feature requests in the [issues](https://github.com/mne-tools/mne-qt-browser/issues) of this repository.
+
+### Development and testing
+
+You can run a benchmark locally with:
+
+```console
+$ pytest -m benchmark mne_qt_browser
+```
+
+To run tests, clone mne-python, and then run the PyQtGraph tests with e.g.:
+```console
+$ pytest -m pgtest ../mne-python/mne/viz/tests
+```

--- a/README.md
+++ b/README.md
@@ -52,3 +52,8 @@ To run tests, clone mne-python, and then run the PyQtGraph tests with e.g.:
 ```console
 $ pytest -m pgtest ../mne-python/mne/viz/tests
 ```
+If you do not have OpenGL installed, this will currently raise errors, and
+you'll need to add this line to `mne/conftest.py` after the `error::` line:
+```
+    ignore:.*PyOpenGL was not found.*:RuntimeWarning
+```

--- a/mne_qt_browser/conftest.py
+++ b/mne_qt_browser/conftest.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# Author: Eric Larson <larson.eric.d@gmail.com>
+#
+# License: BSD-3-Clause
+
+
+import pytest
+
+_store = dict()
+
+
+def pytest_configure(config):
+    """Configure pytest options."""
+    # Markers
+    for marker in ('benchmark',):
+        config.addinivalue_line('markers', marker)
+
+
+@pytest.fixture(scope='session')
+def store():
+    """Yield our storage object."""
+    yield _store
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Print our benchmark results (if present)."""
+    if len(_store):
+        from py.io import TerminalWriter
+        writer = TerminalWriter()
+        writer.line()  # newline
+        writer.sep('=', 'benchmark results')
+        for name, vals in _store.items():
+            writer.line(
+                f'{name}:\n'
+                f'    Horizontal: {vals["h"]:6.2f}\n'
+                f'    Vertical:   {vals["v"]:6.2f}')

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -1,6 +1,7 @@
 pytest
 pytest-qt
 pytest-cov
+pytest-timeout
 pooch
 pyvista  # for mne sys_info to tell us about OpenGL
 tqdm

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,4 @@
 [tool:pytest]
 addopts =
-    --durations=20 -ra --cov-report= --tb=short
-    --junit-xml=junit-results.xml
+    -ra --cov-report= --tb=short --junit-xml=junit-results.xml --capture=sys
 junit_family = xunit2


### PR DESCRIPTION
1. Don't install `upstream/main` for now, use stable
2. Use `upstream/main` rather than `marsipu/pg_test`