### PR TITLE
MNT: adapt to qtapp-centralization in mne-tools/mne-python#10048

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -66,7 +66,7 @@ name = 'pyqtgraph'
 # This can be removed when mne==1.0 is released.
 try:
     from mne.viz.backends._utils import _init_mne_qtapp
-except (ImportError, ModuleNotFoundError):
+except ImportError:
     from mne.viz.backends._utils import _init_qt_resources
 
     def _init_mne_qtapp(enable_icon=True, pg_app=False):

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -92,6 +92,18 @@ except ModuleNotFoundError:
         app_name = 'MNE-Python'
         organization_name = 'MNE'
 
+        # Fix from cbrnr/mnelab for app name in menu bar
+        if sys.platform.startswith("darwin"):
+            try:
+                # set bundle name on macOS (app name shown in the menu bar)
+                from Foundation import NSBundle
+                bundle = NSBundle.mainBundle()
+                info = (bundle.localizedInfoDictionary()
+                        or bundle.infoDictionary())
+                info["CFBundleName"] = app_name
+            except ModuleNotFoundError:
+                pass
+
         if pg_app:
             from pyqtgraph import mkQApp
             app = mkQApp(app_name)
@@ -107,17 +119,6 @@ except ModuleNotFoundError:
             kind = 'bigsur-' if platform.mac_ver()[0] >= '10.16' else ''
             app.setWindowIcon(QIcon(f":/mne-{kind}icon.png"))
 
-        # Fix from cbrnr/mnelab for app name in menu bar
-        if sys.platform.startswith("darwin"):
-            try:
-                # set bundle name on macOS (app name shown in the menu bar)
-                from Foundation import NSBundle
-                bundle = NSBundle.mainBundle()
-                info = (bundle.localizedInfoDictionary()
-                        or bundle.infoDictionary())
-                info["CFBundleName"] = app_name
-            except ModuleNotFoundError:
-                pass
 
         return app
 

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -66,7 +66,7 @@ name = 'pyqtgraph'
 # This can be removed when mne==1.0 is released.
 try:
     from mne.viz.backends._utils import _init_mne_qtapp
-except ModuleNotFoundError:
+except ImportError:
     from mne.viz.backends._utils import _init_qt_resources
 
     def _init_mne_qtapp(enable_icon=True, pg_app=False):

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -66,7 +66,7 @@ name = 'pyqtgraph'
 # This can be removed when mne==1.0 is released.
 try:
     from mne.viz.backends._utils import _init_mne_qtapp
-except ImportError:
+except (ImportError, ModuleNotFoundError):
     from mne.viz.backends._utils import _init_qt_resources
 
     def _init_mne_qtapp(enable_icon=True, pg_app=False):

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -3198,7 +3198,7 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
     def _get_zscore(self, data):
         # Reshape data to reasonable size for display
         if QApplication.desktop() is None:
-            max_pixel_width = 3840  # defaul=UHD
+            max_pixel_width = 3840  # default=UHD
         else:
             max_pixel_width = QApplication.desktop().screenGeometry().width()
         collapse_by = data.shape[1] // max_pixel_width

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -36,11 +36,11 @@ from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from pyqtgraph import (AxisItem, GraphicsView, InfLineLabel, InfiniteLine,
                        LinearRegionItem, PlotCurveItem, PlotItem,
                        Point, TextItem, ViewBox, mkBrush,
-                       mkPen, setConfigOption, mkQApp, mkColor)
+                       mkPen, setConfigOption, mkColor)
 from scipy.stats import zscore
 
 from mne.viz import plot_sensors
-from mne.viz.backends._utils import _init_qt_resources
+from mne.viz.backends._utils import _init_mne_qtapp
 from mne.viz._figure import BrowserBase
 from mne.viz.utils import _simplify_float, _merge_annotations
 from mne.annotations import _sync_onset
@@ -3138,7 +3138,10 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
 
     def _get_zscore(self, data):
         # Reshape data to reasonable size for display
-        max_pixel_width = QApplication.desktop().screenGeometry().width()
+        if QApplication.desktop() is None:
+            max_pixel_width = 1920  # defaul=FHD
+        else:
+            max_pixel_width = QApplication.desktop().screenGeometry().width()
         collapse_by = data.shape[1] // max_pixel_width
         data = data[:, :max_pixel_width * collapse_by]
         if collapse_by > 0:
@@ -3765,12 +3768,7 @@ def _mouseDrag(widget, positions, button, modifier=None):
 def _init_browser(**kwargs):
     setConfigOption('enableExperimental', True)
 
-    app = mkQApp()
-    app.setApplicationName('MNE-Python')
-    app.setOrganizationName('MNE')
-    _init_qt_resources()
-    kind = 'bigsur-' if platform.mac_ver()[0] >= '10.16' else ''
-    app.setWindowIcon(QIcon(f":/mne-{kind}icon.png"))
+    _init_mne_qtapp(pg_app=True)
     browser = PyQtGraphBrowser(**kwargs)
 
     return browser

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -119,7 +119,6 @@ except (ImportError, ModuleNotFoundError):
             kind = 'bigsur-' if platform.mac_ver()[0] >= '10.16' else ''
             app.setWindowIcon(QIcon(f":/mne-{kind}icon.png"))
 
-
         return app
 
 


### PR DESCRIPTION
### Description
This PR adapts to the changes made in mne-tools/mne-python#10048 for the centralization of the Qt-Application intialization.
It should only be merged **after** the aforementioned PR is merged in the maintenance-branch of mne-python.