### PR TITLE
[MAINT] bump `__version__` to dev

### DIFF
--- a/mne_qt_browser/_version.py
+++ b/mne_qt_browser/_version.py
@@ -1,1 +1,2 @@
-__version__ = '0.1.6'
+"""The version number."""
+__version__ = '0.1.7.dev0'


### PR DESCRIPTION
I just installed mne-qt-browser at a specific commit **after** 0.1.6 (06e586a44fc7934b14ad7c0cde89f527bafbd879) to get an unreleased fix ... yet `mne sys_info` still showed me `0.1.6` as the version, which is a bit misleading.

I assumed you are following a "semver"-style of versioning for the proposed changes below.