### PR TITLE
FIX: Accept all matplotlib color-specifiers

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -85,9 +85,8 @@ def _get_color(color_spec):
     try:
         color = mkColor(color_spec)
     except ValueError:
-        logger.critical(f'{color_spec} is not a valid matplotlib '
-                        f'color-specifier!')
-        return mkColor((0, 0, 0, 128))
+        raise ValueError(f'"{color_spec}" is not a valid matplotlib '
+                         f'color-specifier!')
 
     return color
 

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -86,7 +86,7 @@ def _get_color(color_spec):
         color = mkColor(color_spec)
     except ValueError:
         raise ValueError(f'"{color_spec}" is not a valid matplotlib '
-                         f'color-specifier!')
+                         f'color-specifier!') from None
 
     return color
 


### PR DESCRIPTION
## Description
This PR adds a wrapper for pyqtgraph's `mkColor` which makes PyQtGraphBrowser accept [all available matplotlib color-specifiers](https://matplotlib.org/stable/tutorials/colors/colors.html) (especially float-tuples with values from 0-1 where pyqtgraph would need values from 0-255)

## References
Closes mne-tools/mne-python#10059