### PR TITLE
FIX: Annotation-Regions cannot be moved out of bounds

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -1528,7 +1528,8 @@ class AnnotRegion(LinearRegionItem):
 
     def __init__(self, mne, description, values):
         super().__init__(values=values, orientation='vertical',
-                         movable=True, swapMode='sort')
+                         movable=True, swapMode='sort',
+                         bounds=(0, mne.xmax))
         # Set default z-value to 0 to be behind other items in scene
         self.setZValue(0)
 


### PR DESCRIPTION
This fixes a minor bug where it was possible to drag annotation-regions at the lower or upper end of `raw.times` out of bounds.