### PR TITLE
ENH: Epochs support

### DIFF
--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -70,7 +70,7 @@ jobs:
         run: |  # use MNE main to ensure test files are available
           set -e
           python -m pip install --upgrade pip
-          git clone -b pg_epoch_support --single-branch --depth=1 https://github.com/marsipu/mne-python.git ../mne-python
+          git clone -b ${MNE_BRANCH} --single-branch --depth=1 https://github.com/mne-tools/mne-python.git ../mne-python
           python -m pip install -qe ../mne-python
           python -m pip install -ve .${PIP_OPTION} -r requirements.txt -r requirements_testing.txt
       - name: Downgrade pytest for mne==0.24

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -101,8 +101,10 @@ jobs:
         run: mne sys_info
       - run: pytest -m pgtest --cov=mne_qt_browser --cov-report=xml ../mne-python/mne/viz
         name: Run MNE-Tests
-      - run: pytest mne_qt_browser/tests
-        name: Run benchmarks and pg-specific tests
+      - run: pytest mne_qt_browser/tests/test_pg_specific.py
+        name: Run pyqtgraph-specific tests
+      - run: pytest mne_qt_browser/tests/test_speed.py
+        name: Run benchmarks
       - uses: codecov/codecov-action@v1
         if: always()
         name: 'Upload coverage to CodeCov'

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -102,7 +102,7 @@ jobs:
       - run: pytest -m pgtest --cov=mne_qt_browser --cov-report=xml ../mne-python/mne/viz
         name: Run MNE-Tests
       - run: pytest mne_qt_browser/tests
-        name: Run benchmarks
+        name: Run benchmarks and pg-specific tests
       - uses: codecov/codecov-action@v1
         if: always()
         name: 'Upload coverage to CodeCov'

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -70,7 +70,7 @@ jobs:
         run: |  # use MNE main to ensure test files are available
           set -e
           python -m pip install --upgrade pip
-          git clone -b ${MNE_BRANCH} --single-branch --depth=1 https://github.com/mne-tools/mne-python.git ../mne-python
+          git clone -b pg_epoch_support --single-branch --depth=1 https://github.com/marsipu/mne-python.git ../mne-python
           python -m pip install -qe ../mne-python
           python -m pip install -ve .${PIP_OPTION} -r requirements.txt -r requirements_testing.txt
       - name: Downgrade pytest for mne==0.24

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 """Base classes and functions for 2D browser backends."""
 
-# Authors: Martin Schulz <dev@earthman-music.de>
+# Author: Martin Schulz <dev@earthman-music.de>
 #
-# License: Simplified BSD
+# License: BSD-3-Clause
 
 import datetime
 import functools

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -2292,7 +2292,8 @@ class AnnotationDock(QDockWidget):
                 self.main.message_box(text='Invalid value!',
                                       info_text='Start can\'t be bigger or '
                                                 'equal to Stop!',
-                                      icon=QMessageBox.Critical)
+                                      icon=QMessageBox.Critical,
+                                      modal=False)
                 self.start_bx.setValue(sel_region.getRegion()[0])
 
     def _stop_changed(self):
@@ -2540,6 +2541,7 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
 
         # Exactly one MessageBox for messages to facilitate testing/debugging
         self.msg_box = QMessageBox(self)
+        self.test_mode = False
         # A QThread for preloading
         self.load_thread = None
         # A Settings-Dialog
@@ -4077,7 +4079,7 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
         SelectionDialog(self)
 
     def message_box(self, text, info_text=None, buttons=None,
-                    default_button=None, icon=None):
+                    default_button=None, icon=None, modal=True):
         self.msg_box.setText(f'<font size="+2"><b>{text}</b></font>')
         if info_text is not None:
             self.msg_box.setInformativeText(info_text)
@@ -4087,7 +4089,14 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
             self.msg_box.setDefaultButton(default_button)
         if icon is not None:
             self.msg_box.setIcon(icon)
-        return self.msg_box.exec()
+
+        # Allow interacting with message_box in test-mode.
+        # Set modal=False only if no return value is expected.
+        self.msg_box.setModal(False if self.test_mode else modal)
+        if self.test_mode or not modal:
+            self.msg_box.show()
+        else:
+            return self.msg_box.exec()
 
     def keyPressEvent(self, event):
         """Customize key press events."""

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -2729,6 +2729,7 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
         view.sigSceneMouseMoved.connect(self._mouse_moved)
 
         # Initialize Annotation-Widgets
+        self.mne.annotation_mode = False
         if not self.mne.is_epochs:
             self._init_annot_mode()
 
@@ -3797,7 +3798,6 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
         pass
 
     def _init_annot_mode(self):
-        self.mne.annotation_mode = False
         self.mne.annotations_visible = True
         self.mne.new_annotation_labels = self._get_annotation_labels()
         if len(self.mne.new_annotation_labels) > 0:

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -2177,10 +2177,6 @@ class AnnotationDock(QDockWidget):
                                        f'"{rm_description}".\n'
                                        f'Do you really want to remove them?')
             if ans == QMessageBox.Yes:
-                rm_idxs = np.where(
-                    self.mne.inst.annotations.description == rm_description)
-                for idx in rm_idxs:
-                    self.mne.inst.annotations.delete(idx)
                 for rm_region in [r for r in self.mne.regions
                                   if r.description == rm_description]:
                     rm_region.remove()

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -2725,13 +2725,25 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
         if self.mne.use_opengl is None:  # default: opt-in
             self.mne.use_opengl = (
                     get_config('MNE_BROWSE_USE_OPENGL', '').lower() == 'true')
+
+        # Epochs currently only work with OpenGL enabled
+        # (https://github.com/mne-tools/mne-qt-browser/issues/53)
+        mac_epochs = self.mne.is_epochs and sys.platform == 'darwin'
+        if mac_epochs:
+            self.mne.use_opengl = True
+
         if self.mne.use_opengl:
             try:
                 import OpenGL
             except (ModuleNotFoundError, ImportError):
                 warn('PyOpenGL was not found and OpenGL can\'t be used!\n'
-                     'Consider installing pyopengl with "pip install pyopengl"'
+                     'Consider installing pyopengl with pip or conda'
                      'or set "use_opengl" to False to avoid this warning.')
+                if mac_epochs:
+                    warn('Plotting epochs on MacOS without OpenGL'
+                         'is currently highly unstable due to '
+                         'https://github.com/mne-tools/mne-qt-browser/'
+                         'issues/53!')
                 self.mne.use_opengl = False
             else:
                 logger.info(

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -1233,8 +1233,10 @@ class RawViewBox(ViewBox):
                                                  self.mapSceneToView(
                                                      event.scenePos()).x()))
             elif event.isFinish():
-                QMessageBox.warning(self.main, 'No description!',
-                                    'No description is given, add one!')
+                self.main.message_box(text='No description!',
+                                      info_text=
+                                       'No description is given, add one!',
+                                      icon=QMessageBox.Warning)
 
     def mouseClickEvent(self, event):
         """Customize mouse click events."""
@@ -2171,8 +2173,10 @@ class AnnotationDock(QDockWidget):
         if len(self.mne.inst.annotations.description) > 0:
             _AnnotEditDialog(self)
         else:
-            QMessageBox.information(self, 'No Annotations!',
-                                    'There are no annotations yet to edit!')
+            self.main.message_box(text='No Annotations!',
+                                  info_text=
+                                  'There are no annotations yet to edit!',
+                                  icon=QMessageBox.Information)
 
     def _remove_description(self, rm_description):
         # Remove regions
@@ -2202,13 +2206,17 @@ class AnnotationDock(QDockWidget):
         existing_annot = list(self.mne.inst.annotations.description).count(
             rm_description)
         if existing_annot > 0:
-            ans = QMessageBox.question(self,
-                                       f'Remove annotations '
-                                       f'with {rm_description}?',
-                                       f'There exist {existing_annot} '
-                                       f'annotations with '
-                                       f'"{rm_description}".\n'
-                                       f'Do you really want to remove them?')
+            ans = self.main.message_box(text=f'Remove annotations '
+                                             f'with {rm_description}?',
+                                        info_text=
+                                        f'There exist {existing_annot} '
+                                        f'annotations with '
+                                        f'"{rm_description}".\n'
+                                        f'Do you really want to remove them?',
+                                        buttons=
+                                        QMessageBox.Yes | QMessageBox.No,
+                                        default_button=QMessageBox.Yes,
+                                        icon=QMessageBox.Question)
         else:
             ans = QMessageBox.Yes
 
@@ -2282,8 +2290,11 @@ class AnnotationDock(QDockWidget):
             if start < stop:
                 sel_region.setRegion((start, stop))
             else:
-                QMessageBox.warning(self, 'Invalid value!',
-                                    'Start can\'t be bigger or equal to Stop!')
+                self.main.message_box(text='Invalid value!',
+                                      info_text=
+                                      'Start can\'t be bigger or '
+                                      'equal to Stop!',
+                                      icon=QMessageBox.Critical)
                 self.start_bx.setValue(sel_region.getRegion()[0])
 
     def _stop_changed(self):
@@ -2294,9 +2305,11 @@ class AnnotationDock(QDockWidget):
             if start < stop:
                 sel_region.setRegion((start, stop))
             else:
-                QMessageBox.warning(self, 'Invalid value!',
-                                    'Stop can\'t be smaller '
-                                    'or equal to Start!')
+                self.main.message_box(text='Invalid value!',
+                                      info_text=
+                                      'Stop can\'t be smaller '
+                                      'or equal to Start!',
+                                      icon=QMessageBox.Critical)
                 self.stop_bx.setValue(sel_region.getRegion()[1])
 
     def _set_color(self):
@@ -2339,36 +2352,38 @@ class AnnotationDock(QDockWidget):
         self.stop_bx.setValue(0)
 
     def _show_help(self):
-        QMessageBox.information(self, 'Annotations-Help',
-                                '<h1>Help</h1>'
-                                '<h2>Annotations</h2>'
-                                '<h3>Add Annotations</h3>'
-                                'Drag inside the data-view to create '
-                                'annotations with the description currently '
-                                'selected (leftmost item of the toolbar).'
-                                'If there is no description yet, add one '
-                                'with the button "Add description".'
-                                '<h3>Remove Annotations</h3>'
-                                'You can remove single annotations by '
-                                'right-clicking on them.'
-                                '<h3>Edit Annotations</h3>'
-                                'You can edit annotations by dragging them or '
-                                'their boundaries. Or you can use the dials '
-                                'in the toolbar to adjust the boundaries for '
-                                'the current selected annotation.'
-                                '<h2>Descriptions</h2>'
-                                '<h3>Add Description</h3>'
-                                'Add a new description with the button'
-                                '"Add description".'
-                                '<h3>Edit Description</h3>'
-                                'You can edit the description of one single '
-                                'annotation or all annotations of the '
-                                'currently selected kind with the button '
-                                '"Edit description".'
-                                '<h3>Remove Description</h3>'
-                                'You can remove all annotations of the '
-                                'currently selected kind with the button '
-                                '"Remove description".')
+        self.main.message_box(text='Annotations-Help',
+                              info_text=
+                              '<h1>Help</h1>'
+                              '<h2>Annotations</h2>'
+                              '<h3>Add Annotations</h3>'
+                              'Drag inside the data-view to create '
+                              'annotations with the description currently '
+                              'selected (leftmost item of the toolbar).'
+                              'If there is no description yet, add one '
+                              'with the button "Add description".'
+                              '<h3>Remove Annotations</h3>'
+                              'You can remove single annotations by '
+                              'right-clicking on them.'
+                              '<h3>Edit Annotations</h3>'
+                              'You can edit annotations by dragging them or '
+                              'their boundaries. Or you can use the dials '
+                              'in the toolbar to adjust the boundaries for '
+                              'the current selected annotation.'
+                              '<h2>Descriptions</h2>'
+                              '<h3>Add Description</h3>'
+                              'Add a new description with the button'
+                              '"Add description".'
+                              '<h3>Edit Description</h3>'
+                              'You can edit the description of one single '
+                              'annotation or all annotations of the '
+                              'currently selected kind with the button '
+                              '"Edit description".'
+                              '<h3>Remove Description</h3>'
+                              'You can remove all annotations of the '
+                              'currently selected kind with the button '
+                              '"Remove description".',
+                              icon=QMessageBox.Information)
 
 
 class BrowserView(GraphicsView):
@@ -2528,7 +2543,12 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
 
         # Initialize attributes which are only used by pyqtgraph, not by
         # matplotlib and add them to MNEBrowseParams.
+
+        # Exactly one MessageBox for messages to facilitate testing/debugging
+        self.msg_box = QMessageBox(self)
+        # A QThread for preloading
         self.load_thread = None
+        # A Settings-Dialog
         self.mne.fig_settings = None
         self.mne.decim_data = None
         self.mne.decim_times = None
@@ -4061,7 +4081,20 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
 
     def _create_selection_fig(self):
         SelectionDialog(self)
-
+    
+    def message_box(self, text, info_text=None, buttons=None,
+                    default_button=None, icon=None):
+        self.msg_box.setText(f'<font size="+2"><b>{text}</b></font>')
+        if info_text is not None:
+            self.msg_box.setInformativeText(info_text)
+        if buttons is not None:
+            self.msg_box.setStandardButtons(buttons)
+        if default_button is not None:
+            self.msg_box.setDefaultButton(default_button)
+        if icon is not None:
+            self.msg_box.setIcon(icon)
+        return self.msg_box.exec()
+    
     def keyPressEvent(self, event):
         """Customize key press events."""
         # On MacOs additionally KeypadModifier is set when arrow-keys

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -588,7 +588,7 @@ class ChannelAxis(AxisItem):
                              if k in [tr.ch_name for tr in self.mne.traces]}
             # Get channel-name from position of channel-description
             ypos = event.scenePos().y()
-            y_values = np.asarray(list(self.ch_texts.values()))[ :, 1, :]
+            y_values = np.asarray(list(self.ch_texts.values()))[:, 1, :]
             y_diff = np.abs(y_values - ypos)
             ch_idx = int(np.argmin(y_diff, axis=0)[0])
             ch_name = list(self.ch_texts.keys())[ch_idx]

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -2412,7 +2412,7 @@ class LoadThread(QThread):
                     / self.mne.info['sfreq']
         else:
             times = None
-        n_chunks = 10
+        n_chunks = min(10, len(self.mne.inst))
         chunk_size = len(self.mne.inst) // n_chunks
         for n in range(n_chunks):
             start = n * chunk_size

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -2822,10 +2822,11 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
         aincr_nchan.triggered.connect(partial(self.scale_all, 5 / 4))
         toolbar.addAction(aincr_nchan)
 
-        atoggle_annot = QAction(_get_std_icon('SP_DialogResetButton'),
-                                'Annotations', parent=self)
-        atoggle_annot.triggered.connect(self._toggle_annotation_fig)
-        toolbar.addAction(atoggle_annot)
+        if not self.mne.is_epochs:
+            atoggle_annot = QAction(_get_std_icon('SP_DialogResetButton'),
+                                    'Annotations', parent=self)
+            atoggle_annot.triggered.connect(self._toggle_annotation_fig)
+            toolbar.addAction(atoggle_annot)
 
         atoggle_proj = QAction(_get_std_icon('SP_DialogOkButton'),
                                'SSP', parent=self)

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -33,7 +33,8 @@ from PyQt5.QtWidgets import (QAction, QColorDialog, QComboBox, QDialog,
                              QGraphicsLineItem, QGraphicsScene, QTextEdit,
                              QSizePolicy, QSpinBox, QDesktopWidget, QSlider)
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
-from pyqtgraph import (AxisItem, GraphicsView, InfLineLabel, InfiniteLine,
+from pyqtgraph import (AxisItem, GraphicsView, GridItem, InfLineLabel,
+                       InfiniteLine,
                        LinearRegionItem, PlotCurveItem, PlotItem,
                        Point, TextItem, ViewBox, mkBrush,
                        mkPen, setConfigOption, mkColor)
@@ -2289,9 +2290,16 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
         for ch_idx in self.mne.picks:
             self._add_trace(ch_idx)
 
-        # Add events (add all once, since their representation is simple
-        # they shouldn't have a big impact on performance when showing them
-        # is handled by QGraphicsView).
+        # Initialize Epochs Grid
+        if self.mne.is_epochs:
+            grid_pen = mkPen(color='k', width=2, style=Qt.DashLine)
+            for x_grid in self.mne.boundary_times[1:-1]:
+                grid_line = InfiniteLine(pos=x_grid,
+                                         pen=grid_pen,
+                                         movable=False)
+                plt.addItem(grid_line)
+
+        # Add events
         if self.mne.event_nums is not None:
             self.mne.events_visible = True
             for ev_time, ev_id in zip(self.mne.event_times,

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -3182,7 +3182,10 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
         if self.mne.is_epochs:
             # use the length of one epoch as duration change
             min_dur = len(self.mne.inst.times) / self.mne.info['sfreq']
-            rel_step = min_dur * (1 if step > 0 else -1)
+            step_dir = (1 if step > 0 else -1)
+            rel_step = min_dur * step_dir
+            self.mne.n_epochs = np.clip(self.mne.n_epochs + step_dir,
+                                        1, len(self.mne.inst))
         else:
             # never show fewer than 3 samples
             min_dur = 3 * np.diff(self.mne.inst.times[:2])[0]

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -485,7 +485,7 @@ class TimeAxis(AxisItem):
         """Customize strings of axis values."""
         if self.mne.is_epochs:
             epoch_nums = self.mne.inst.selection
-            ts = epoch_nums[np.in1d(self.mne.midpoints, values).nonzero()[0]]
+            ts = epoch_nums[np.searchsorted(self.mne.midpoints, values)]
             tick_strings = [str(v) for v in ts]
 
         elif self.mne.time_format == 'clock':

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -2570,7 +2570,6 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
                             to_rgba_array(color)
 
             # Mark bad epochs
-            self.mne.bad_epochs.append(2)
             self.mne.epoch_color_ref[:, self.mne.bad_epochs] = \
                 to_rgba_array(self.mne.epoch_color_bad)
 

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -2859,7 +2859,10 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
         plt.setXRange(self.mne.t_start,
                       self.mne.t_start + self.mne.duration,
                       padding=0)
-        plt.setYRange(0, self.mne.n_channels + 1, padding=0)
+        if self.mne.butterfly:
+            self._set_butterfly(True)
+        else:
+            plt.setYRange(0, self.mne.n_channels + 1, padding=0)
 
         # Set Size
         width = int(self.mne.figsize[0] * self.logicalDpiX())
@@ -3165,6 +3168,8 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
             else:
                 step = int(step)
             self.mne.fig_selection._scroll_selection(step)
+        elif self.mne.butterfly:
+            return
         else:
             # Get current range and add step to it
             if step == '+full':
@@ -3950,13 +3955,16 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
                 for pick in picks:
                     self.mne.selection_ypos_dict[pick] = idx + 1
             ymax = len(selections_dict) + 1
+            self.mne.ymax = ymax
             self.mne.plt.setLimits(yMax=ymax)
             self.mne.plt.setYRange(0, ymax, padding=0)
         elif butterfly:
             ymax = len(self.mne.butterfly_type_order) + 1
+            self.mne.ymax = ymax
             self.mne.plt.setLimits(yMax=ymax)
             self.mne.plt.setYRange(0, ymax, padding=0)
         else:
+            self.mne.ymax = len(self.mne.ch_order) + 1
             self.mne.plt.setLimits(yMax=self.mne.ymax)
             self.mne.plt.setYRange(self.mne.ch_start,
                                    self.mne.ch_start + self.mne.n_channels + 1,

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -153,8 +153,11 @@ class RawTraceItem(PlotCurveItem):
     """Graphics-Object for single data trace."""
 
     def __init__(self, mne, ch_idx, child=False):
-        super().__init__(clickable=True)
+        super().__init__()
         self.mne = mne
+
+        # Set clickable with small area around trace to make clicking easier.
+        self.setClickable(True, 12)
 
         # Set default z-value to 1 to be before other items in scene
         self.setZValue(1)

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -592,10 +592,10 @@ class ChannelAxis(AxisItem):
             y_diff = np.abs(y_values - ypos)
             ch_idx = int(np.argmin(y_diff, axis=0)[0])
             ch_name = list(self.ch_texts.keys())[ch_idx]
-                trace = [tr for tr in self.mne.traces
-                         if tr.ch_name == ch_name][0]
-                if event.button() == Qt.LeftButton:
-                    self.main._bad_ch_clicked(trace)  # without x always toggles channel
+            trace = [tr for tr in self.mne.traces
+                     if tr.ch_name == ch_name][0]
+            if event.button() == Qt.LeftButton:
+                trace.toggle_bad()
             elif event.button() == Qt.RightButton:
                 self.main._create_ch_context_fig(trace.range_idx)
 

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -65,7 +65,6 @@ except ImportError:
 
 name = 'pyqtgraph'
 
-
 # This can be removed when mne==1.0 is released.
 try:
     from mne.viz.backends._utils import _init_mne_qtapp
@@ -127,7 +126,7 @@ except ImportError:
 
 def _get_std_icon(icon_name):
     return QApplication.instance().style().standardIcon(
-        getattr(QStyle, icon_name))
+            getattr(QStyle, icon_name))
 
 
 def _get_color(color_spec):
@@ -163,6 +162,7 @@ def propagate_to_children(method):
                 for child_trace in args[0].child_traces:
                     getattr(child_trace, method.__name__)(*args[1:], **kwargs)
         return result
+
     return wrapper
 
 
@@ -371,7 +371,7 @@ class RawTraceItem(PlotCurveItem):
                         [to_rgba_array(c) for c
                          in self.mne.ch_color_ref.values()])
             else:
-                new_epo_color =\
+                new_epo_color = \
                     np.concatenate([to_rgba_array(c) for c in
                                     self.mne.epoch_colors[epoch_idx]])
 
@@ -611,8 +611,8 @@ class BaseScrollBar(QScrollBar):
             opt = QStyleOptionSlider()
             self.initStyleOption(opt)
             control = self.style().hitTestComplexControl(
-                QStyle.CC_ScrollBar, opt,
-                event.pos(), self)
+                    QStyle.CC_ScrollBar, opt,
+                    event.pos(), self)
             if (control == QStyle.SC_ScrollBarAddPage or
                     control == QStyle.SC_ScrollBarSubPage):
                 # scroll here
@@ -637,8 +637,9 @@ class BaseScrollBar(QScrollBar):
                     sliderMin = gr.y()
                     sliderMax = gr.bottom() - sliderLength + 1
                 self.setValue(QStyle.sliderValueFromPosition(
-                    self.minimum(), self.maximum(),
-                    pos - sliderMin, sliderMax - sliderMin, opt.upsideDown))
+                        self.minimum(), self.maximum(),
+                        pos - sliderMin, sliderMax - sliderMin,
+                        opt.upsideDown))
                 return
 
         return super().mousePressEvent(event)
@@ -1183,7 +1184,7 @@ class RawViewBox(ViewBox):
                 description = self.mne.current_description
                 if event.isStart():
                     self._drag_start = self.mapSceneToView(
-                        event.lastScenePos()).x()
+                            event.lastScenePos()).x()
                     drag_stop = self.mapSceneToView(event.scenePos()).x()
                     self._drag_region = AnnotRegion(self.mne,
                                                     description=description,
@@ -1229,13 +1230,13 @@ class RawViewBox(ViewBox):
                     # Update Overview-Bar
                     self.mne.overview_bar.update_annotations()
                 else:
-                    self._drag_region.setRegion((self._drag_start,
-                                                 self.mapSceneToView(
-                                                     event.scenePos()).x()))
+                    x_to = self.mapSceneToView(event.scenePos()).x()
+                    self._drag_region.setRegion((self._drag_start, x_to))
+
             elif event.isFinish():
                 self.main.message_box(text='No description!',
-                                      info_text=
-                                       'No description is given, add one!',
+                                      info_text='No description is given, '
+                                                'add one!',
                                       icon=QMessageBox.Warning)
 
     def mouseClickEvent(self, event):
@@ -1245,7 +1246,7 @@ class RawViewBox(ViewBox):
         if not self.mne.annotation_mode:
             if event.button() == Qt.LeftButton:
                 self.main._add_vline(self.mapSceneToView(
-                    event.scenePos()).x())
+                        event.scenePos()).x())
             elif event.button() == Qt.RightButton:
                 self.main._remove_vline()
 
@@ -1503,31 +1504,31 @@ class SettingsDialog(_BaseDialog):
         self.downsampling_box.setMinimum(0)
         self.downsampling_box.setSpecialValueText('Auto')
         self.downsampling_box.valueChanged.connect(partial(
-            self._value_changed, value_name='downsampling'))
+                self._value_changed, value_name='downsampling'))
         self.downsampling_box.setValue(0 if self.mne.downsampling == 'auto'
                                        else self.mne.downsampling)
         layout.addRow('downsampling', self.downsampling_box)
 
         self.ds_method_cmbx = QComboBox()
         self.ds_method_cmbx.setToolTip(
-            '<h2>Downsampling Method</h2>'
-            '<ul>'
-            '<li>subsample:<br>'
-            'Only take every n-th sample.</li>'
-            '<li>mean:<br>'
-            'Take the mean of n samples.</li>'
-            '<li>peak:<br>'
-            'Draws a saw wave from the minimum to the maximum from a '
-            'collection of n samples.</li>'
-            '</ul>'
-            '<i>(Those methods are adapted from '
-            'pyqtgraph)</i><br>'
-            'Default is "peak".')
+                '<h2>Downsampling Method</h2>'
+                '<ul>'
+                '<li>subsample:<br>'
+                'Only take every n-th sample.</li>'
+                '<li>mean:<br>'
+                'Take the mean of n samples.</li>'
+                '<li>peak:<br>'
+                'Draws a saw wave from the minimum to the maximum from a '
+                'collection of n samples.</li>'
+                '</ul>'
+                '<i>(Those methods are adapted from '
+                'pyqtgraph)</i><br>'
+                'Default is "peak".')
         self.ds_method_cmbx.addItems(['subsample', 'mean', 'peak'])
         self.ds_method_cmbx.currentTextChanged.connect(partial(
-            self._value_changed, value_name='ds_method'))
+                self._value_changed, value_name='ds_method'))
         self.ds_method_cmbx.setCurrentText(
-            self.mne.ds_method)
+                self.mne.ds_method)
         layout.addRow('ds_method', self.ds_method_cmbx)
 
         self.scroll_sensitivity_slider = QSlider(Qt.Horizontal)
@@ -1537,7 +1538,7 @@ class SettingsDialog(_BaseDialog):
                                                   'the scrolling in '
                                                   'horizontal direction.')
         self.scroll_sensitivity_slider.valueChanged.connect(partial(
-            self._value_changed, value_name='scroll_sensitivity'))
+                self._value_changed, value_name='scroll_sensitivity'))
         # Set default
         self.scroll_sensitivity_slider.setValue(self.mne.scroll_sensitivity)
         layout.addRow('horizontal scroll sensitivity',
@@ -1859,7 +1860,7 @@ class SelectionDialog(_BaseDialog):
 
     def _scroll_selection(self, step):
         name_idx = list(self.mne.ch_selections.keys()).index(
-            self.mne.old_selection)
+                self.mne.old_selection)
         new_idx = np.clip(name_idx + step,
                           0, len(self.mne.ch_selections) - 1)
         new_label = list(self.mne.ch_selections.keys())[new_idx]
@@ -2156,12 +2157,12 @@ class AnnotationDock(QDockWidget):
         # Update containers with annotation-attributes
         if new_des not in self.mne.new_annotation_labels:
             self.mne.new_annotation_labels.append(new_des)
-        self.mne.visible_annotations[new_des] =\
+        self.mne.visible_annotations[new_des] = \
             copy(self.mne.visible_annotations[old_des])
         if old_des not in self.mne.inst.annotations.description:
             self.mne.new_annotation_labels.remove(old_des)
             self.mne.visible_annotations.pop(old_des)
-            self.mne.annotation_segment_colors[new_des] =\
+            self.mne.annotation_segment_colors[new_des] = \
                 self.mne.annotation_segment_colors.pop(old_des)
 
         # Update related widgets
@@ -2174,8 +2175,8 @@ class AnnotationDock(QDockWidget):
             _AnnotEditDialog(self)
         else:
             self.main.message_box(text='No Annotations!',
-                                  info_text=
-                                  'There are no annotations yet to edit!',
+                                  info_text='There are no annotations '
+                                            'yet to edit!',
                                   icon=QMessageBox.Information)
 
     def _remove_description(self, rm_description):
@@ -2204,17 +2205,15 @@ class AnnotationDock(QDockWidget):
     def _remove_description_dlg(self):
         rm_description = self.description_cmbx.currentText()
         existing_annot = list(self.mne.inst.annotations.description).count(
-            rm_description)
+                rm_description)
         if existing_annot > 0:
-            ans = self.main.message_box(text=f'Remove annotations '
-                                             f'with {rm_description}?',
-                                        info_text=
-                                        f'There exist {existing_annot} '
-                                        f'annotations with '
-                                        f'"{rm_description}".\n'
-                                        f'Do you really want to remove them?',
-                                        buttons=
-                                        QMessageBox.Yes | QMessageBox.No,
+            text = f'Remove annotations with {rm_description}?'
+            info_text = f'There exist {existing_annot} annotations with ' \
+                        f'"{rm_description}".\n' \
+                        f'Do you really want to remove them?'
+            buttons = QMessageBox.Yes | QMessageBox.No
+            ans = self.main.message_box(text=text, info_text=info_text,
+                                        buttons=buttons,
                                         default_button=QMessageBox.Yes,
                                         icon=QMessageBox.Question)
         else:
@@ -2291,9 +2290,8 @@ class AnnotationDock(QDockWidget):
                 sel_region.setRegion((start, stop))
             else:
                 self.main.message_box(text='Invalid value!',
-                                      info_text=
-                                      'Start can\'t be bigger or '
-                                      'equal to Stop!',
+                                      info_text='Start can\'t be bigger or '
+                                                'equal to Stop!',
                                       icon=QMessageBox.Critical)
                 self.start_bx.setValue(sel_region.getRegion()[0])
 
@@ -2306,9 +2304,8 @@ class AnnotationDock(QDockWidget):
                 sel_region.setRegion((start, stop))
             else:
                 self.main.message_box(text='Invalid value!',
-                                      info_text=
-                                      'Stop can\'t be smaller '
-                                      'or equal to Start!',
+                                      info_text='Stop can\'t be smaller or '
+                                                'equal to Start!',
                                       icon=QMessageBox.Critical)
                 self.stop_bx.setValue(sel_region.getRegion()[1])
 
@@ -2352,37 +2349,34 @@ class AnnotationDock(QDockWidget):
         self.stop_bx.setValue(0)
 
     def _show_help(self):
+        info_text = '<h1>Help</h1>' \
+                    '<h2>Annotations</h2>' \
+                    '<h3>Add Annotations</h3>' \
+                    'Drag inside the data-view to create annotations with '\
+                    'the description currently selected (leftmost item of '\
+                    'the toolbar).If there is no description yet, add one ' \
+                    'with the button "Add description".' \
+                    '<h3>Remove Annotations</h3>' \
+                    'You can remove single annotations by right-clicking on '\
+                    'them.' \
+                    '<h3>Edit Annotations</h3>' \
+                    'You can edit annotations by dragging them or their '\
+                    'boundaries. Or you can use the dials in the toolbar to '\
+                    'adjust the boundaries for the current selected '\
+                    'annotation.' \
+                    '<h2>Descriptions</h2>' \
+                    '<h3>Add Description</h3>' \
+                    'Add a new description with ' \
+                    'the button "Add description".' \
+                    '<h3>Edit Description</h3>' \
+                    'You can edit the description of one single annotation '\
+                    'or all annotations of the currently selected kind with '\
+                    'the button "Edit description".' \
+                    '<h3>Remove Description</h3>' \
+                    'You can remove all annotations of the currently '\
+                    'selected kind with the button "Remove description".'
         self.main.message_box(text='Annotations-Help',
-                              info_text=
-                              '<h1>Help</h1>'
-                              '<h2>Annotations</h2>'
-                              '<h3>Add Annotations</h3>'
-                              'Drag inside the data-view to create '
-                              'annotations with the description currently '
-                              'selected (leftmost item of the toolbar).'
-                              'If there is no description yet, add one '
-                              'with the button "Add description".'
-                              '<h3>Remove Annotations</h3>'
-                              'You can remove single annotations by '
-                              'right-clicking on them.'
-                              '<h3>Edit Annotations</h3>'
-                              'You can edit annotations by dragging them or '
-                              'their boundaries. Or you can use the dials '
-                              'in the toolbar to adjust the boundaries for '
-                              'the current selected annotation.'
-                              '<h2>Descriptions</h2>'
-                              '<h3>Add Description</h3>'
-                              'Add a new description with the button'
-                              '"Add description".'
-                              '<h3>Edit Description</h3>'
-                              'You can edit the description of one single '
-                              'annotation or all annotations of the '
-                              'currently selected kind with the button '
-                              '"Edit description".'
-                              '<h3>Remove Description</h3>'
-                              'You can remove all annotations of the '
-                              'currently selected kind with the button '
-                              '"Remove description".',
+                              info_text=info_text,
                               icon=QMessageBox.Information)
 
 
@@ -2435,7 +2429,7 @@ class LoadThread(QThread):
         # Thus n_chunks = 10 should suffice.
         data = None
         if self.mne.is_epochs:
-            times = np.arange(len(self.mne.inst) * len(self.mne.inst.times))\
+            times = np.arange(len(self.mne.inst) * len(self.mne.inst.times)) \
                     / self.mne.info['sfreq']
         else:
             times = None
@@ -2521,7 +2515,7 @@ qsettings_params = {
     'downsampling': 1,
     # Downsampling-Method (set SettingsDialog for details)
     'ds_method': 'peak'
-    }
+}
 
 
 class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
@@ -2607,7 +2601,7 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
 
             # Mark bad channels
             bad_idxs = np.in1d(self.mne.ch_names, self.mne.info['bads'])
-            self.mne.epoch_color_ref[bad_idxs, :] =\
+            self.mne.epoch_color_ref[bad_idxs, :] = \
                 to_rgba_array(self.mne.ch_color_bad)
 
         # Add Load-Progressbar for loading in a thread
@@ -2698,7 +2692,7 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
         # Check for OpenGL
         if self.mne.use_opengl is None:  # default: opt-in
             self.mne.use_opengl = (
-                get_config('MNE_BROWSE_USE_OPENGL', '').lower() == 'true')
+                    get_config('MNE_BROWSE_USE_OPENGL', '').lower() == 'true')
         if self.mne.use_opengl:
             try:
                 import OpenGL
@@ -2709,7 +2703,7 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
                 self.mne.use_opengl = False
             else:
                 logger.info(
-                    f'Using pyopengl with version {OpenGL.__version__}')
+                        f'Using pyopengl with version {OpenGL.__version__}')
         # Initialize BrowserView (inherits QGraphicsView)
         view = BrowserView(plt, background='w',
                            useOpenGL=self.mne.use_opengl)
@@ -2760,7 +2754,7 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
         if self.mne.enable_precompute:
             self.overview_mode_chkbx.addItems(['zscore'])
         self.overview_mode_chkbx.currentTextChanged.connect(
-            self._overview_mode_changed)
+                self._overview_mode_changed)
         self.overview_mode_chkbx.setCurrentIndex(0)
         # Avoid taking keyboard-focus
         self.overview_mode_chkbx.setFocusPolicy(Qt.NoFocus)
@@ -2835,8 +2829,9 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
 
         # Add GUI-Elements to MNEBrowserParams-Instance
         vars(self.mne).update(
-            plt=plt, view=view, ax_hscroll=ax_hscroll, ax_vscroll=ax_vscroll,
-            overview_bar=overview_bar, toolbar=toolbar
+                plt=plt, view=view, ax_hscroll=ax_hscroll,
+                ax_vscroll=ax_vscroll,
+                overview_bar=overview_bar, toolbar=toolbar
         )
 
         # Set Start-Range (after all necessary elements are initialized)
@@ -3064,7 +3059,6 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
                         ct in self.mne.scalings and
                         ct in getattr(self.mne, 'units', {}) and
                         ct in getattr(self.mne, 'unit_scalings', {})]:
-
             scale_bar = ScaleBar(self.mne, ch_type)
             self.mne.scalebars[ch_type] = scale_bar
             self.mne.plt.addItem(scale_bar)
@@ -3670,8 +3664,8 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
             # decim can vary by channel type,
             # so compute different `times` vectors.
             self.mne.decim_times = {decim_value: self.mne.times[::decim_value]
-                                    + self.mne.first_time for
-                                    decim_value in set(self.mne.decim_data)}
+                                    + self.mne.first_time for decim_value
+                                    in set(self.mne.decim_data)}
 
         # Apply clipping
         if self.mne.clipping == 'clamp':
@@ -3729,7 +3723,7 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
             region = AnnotRegion(self.mne, description=description,
                                  values=(plot_onset, plot_onset + duration))
         if (any([self.mne.t_start < v < self.mne.t_start + self.mne.duration
-                for v in [plot_onset, plot_onset + duration]]) and
+                 for v in [plot_onset, plot_onset + duration]]) and
                 region not in self.mne.plt.items):
             self.mne.plt.addItem(region)
             self.mne.plt.addItem(region.label_item)
@@ -3737,7 +3731,7 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
         region.gotSelected.connect(self._region_selected)
         region.removeRequested.connect(self._remove_region)
         self.mne.viewbox.sigYRangeChanged.connect(
-            region.update_label_pos)
+                region.update_label_pos)
         self.mne.regions.append(region)
 
         region.update_label_pos()
@@ -3858,7 +3852,7 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
     def _update_regions_visible(self):
         for region in self.mne.regions:
             region.update_visible(
-                self.mne.visible_annotations[region.description])
+                    self.mne.visible_annotations[region.description])
         self.mne.overview_bar.update_annotations()
 
     def _set_annotations_visible(self, visible):
@@ -4081,7 +4075,7 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
 
     def _create_selection_fig(self):
         SelectionDialog(self)
-    
+
     def message_box(self, text, info_text=None, buttons=None,
                     default_button=None, icon=None):
         self.msg_box.setText(f'<font size="+2"><b>{text}</b></font>')
@@ -4094,7 +4088,7 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
         if icon is not None:
             self.msg_box.setIcon(icon)
         return self.msg_box.exec()
-    
+
     def keyPressEvent(self, event):
         """Customize key press events."""
         # On MacOs additionally KeypadModifier is set when arrow-keys
@@ -4209,7 +4203,7 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
             point = self.mne.viewbox.mapViewToScene(Point(*point))
             for idx, apoint in enumerate(add_points):
                 add_points[idx] = self.mne.viewbox.mapViewToScene(
-                    Point(*apoint))
+                        Point(*apoint))
 
         elif xform == 'none' or xform is None:
             if isinstance(point, (tuple, list)):

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -2543,7 +2543,7 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
         self.msg_box = QMessageBox(self)
         self.test_mode = False
         # A QThread for preloading
-        self.load_thread = None
+        self.load_thread = LoadThread(self)
         # A Settings-Dialog
         self.mne.fig_settings = None
         self.mne.decim_data = None
@@ -3573,7 +3573,6 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
             # Start precompute thread
             self.mne.load_progressbar.show()
             self.mne.load_prog_label.show()
-            self.load_thread = LoadThread(self)
             self.load_thread.loadProgress.connect(self.mne.
                                                   load_progressbar.setValue)
             self.load_thread.processText.connect(self._show_process)

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -2741,9 +2741,7 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
                      'or set "use_opengl" to False to avoid this warning.')
                 if mac_epochs:
                     warn('Plotting epochs on MacOS without OpenGL'
-                         'is currently highly unstable due to '
-                         'https://github.com/mne-tools/mne-qt-browser/'
-                         'issues/53!')
+                         'may be unstable!')
                 self.mne.use_opengl = False
             else:
                 logger.info(

--- a/mne_qt_browser/_version.py
+++ b/mne_qt_browser/_version.py
@@ -1,2 +1,2 @@
 """The version number."""
-__version__ = '0.1.8.dev0'
+__version__ = '0.2.0'

--- a/mne_qt_browser/conftest.py
+++ b/mne_qt_browser/conftest.py
@@ -1,22 +1,15 @@
 # -*- coding: utf-8 -*-
-# Author: Eric Larson <larson.eric.d@gmail.com>
+# Authors: Eric Larson <larson.eric.d@gmail.com>
+#          Martin Schulz <dev@earthman-music.de>
 #
 # License: BSD-3-Clause
 
 
 import pytest
 
-from mne.viz import use_browser_backend
 from mne.conftest import (raw_orig, pg_backend, garbage_collect)  # noqa: F401
 
 _store = dict()
-
-
-@pytest.fixture
-def browser_backend(garbage_collect):  # noqa: F811
-    """Parametrizes the name of the browser backend."""
-    with use_browser_backend('pyqtgraph') as backend:
-        yield backend
 
 
 def pytest_configure(config):

--- a/mne_qt_browser/conftest.py
+++ b/mne_qt_browser/conftest.py
@@ -9,7 +9,8 @@ import pytest
 
 from mne.conftest import (raw_orig, pg_backend, garbage_collect)  # noqa: F401
 
-_store = dict()
+_store = {'Raw': {},
+          'Epochs': {}}
 
 
 def pytest_configure(config):
@@ -32,8 +33,10 @@ def pytest_sessionfinish(session, exitstatus):
         writer = TerminalWriter()
         writer.line()  # newline
         writer.sep('=', 'benchmark results')
-        for name, vals in _store.items():
-            writer.line(
-                f'{name}:\n'
-                f'    Horizontal: {vals["h"]:6.2f}\n'
-                f'    Vertical:   {vals["v"]:6.2f}')
+        for type_name, results in _store.items():
+            writer.sep('-', type_name)
+            for name, vals in results.items():
+                writer.line(
+                    f'{name}:\n'
+                    f'    Horizontal: {vals["h"]:6.2f}\n'
+                    f'    Vertical:   {vals["v"]:6.2f}')

--- a/mne_qt_browser/tests/test_pg_specific.py
+++ b/mne_qt_browser/tests/test_pg_specific.py
@@ -1,0 +1,55 @@
+import numpy as np
+
+
+def test_annotations_interactions(raw_orig, browser_backend):
+    """Test interactions specific to pyqtgraph-backend."""
+    # Add test-annotations
+    onsets = np.arange(2, 8, 2) + raw_orig.first_time
+    durations = np.repeat(1, len(onsets))
+    descriptions = ['A', 'B', 'C']
+    for onset, duration, description in zip(onsets, durations, descriptions):
+        raw_orig.annotations.append(onset, duration, description)
+    n_anns = len(raw_orig.annotations)
+    fig = raw_orig.plot()
+    annot_dock = fig.mne.fig_annotation
+
+    # Activate annotation_mode
+    fig._fake_keypress('a')
+
+    # Set current description to index 1
+    annot_dock.description_cmbx.activated.emit(1)
+    assert fig.mne.current_description == 'B'
+
+    # Draw additional annotation
+    fig._fake_click((8., 1.), add_points=[(9., 1.)], xform='data', button=1,
+                    kind='drag')
+    assert len(raw_orig.annotations.onset) == n_anns + 1
+    assert len(raw_orig.annotations.duration) == n_anns + 1
+    assert len(raw_orig.annotations.description) == n_anns + 1
+    assert raw_orig.annotations.description[-1] == 'B'
+
+    # Test remove all regions description
+    annot_dock._remove_description('B')
+    assert len(raw_orig.annotations.onset) == n_anns - 1
+    assert len(raw_orig.annotations.duration) == n_anns - 1
+    assert len(raw_orig.annotations.description) == n_anns - 1
+    assert fig.mne.current_description == 'A'
+    assert fig.mne.selected_region is None
+
+    # Redraw annotation (now with 'A')
+    fig._fake_click((4., 1.), add_points=[(5., 1.)], xform='data', button=1,
+                    kind='drag')
+    assert len(raw_orig.annotations.onset) == n_anns
+    assert len(raw_orig.annotations.duration) == n_anns
+    assert len(raw_orig.annotations.description) == n_anns
+
+    # Test editing descriptions (all)
+    annot_dock._edit_description_all('D')
+    assert len(np.where(raw_orig.annotations.description == 'D')[0]) == 2
+
+    # Test editing descriptions (selected)
+    # Select second region
+    fig._fake_click((4.5, 1.), xform='data')
+    assert fig.mne.selected_region.description == 'D'
+    annot_dock._edit_description_selected('E')
+    assert raw_orig.annotations.description[1] == 'E'

--- a/mne_qt_browser/tests/test_pg_specific.py
+++ b/mne_qt_browser/tests/test_pg_specific.py
@@ -11,6 +11,7 @@ def test_annotations_interactions(raw_orig, browser_backend):
         raw_orig.annotations.append(onset, duration, description)
     n_anns = len(raw_orig.annotations)
     fig = raw_orig.plot()
+    fig.test_mode = True
     annot_dock = fig.mne.fig_annotation
 
     # Activate annotation_mode
@@ -53,3 +54,25 @@ def test_annotations_interactions(raw_orig, browser_backend):
     assert fig.mne.selected_region.description == 'D'
     annot_dock._edit_description_selected('E')
     assert raw_orig.annotations.description[1] == 'E'
+
+    # Test Spinbox behaviour
+    # Update of Spinboxes
+    fig._fake_click((2.5, 1.), xform='data')
+    assert annot_dock.start_bx.value() == 2.
+    assert annot_dock.stop_bx.value() == 3.
+
+    # Setting values with Spinboxex
+    annot_dock.start_bx.setValue(1.5)
+    annot_dock.start_bx.editingFinished.emit()
+    annot_dock.stop_bx.setValue(3.5)
+    annot_dock.stop_bx.editingFinished.emit()
+    assert raw_orig.annotations.onset[0] == 1.5 + raw_orig.first_time
+    assert raw_orig.annotations.duration[0] == 2.
+
+    # Test SpinBox Warning
+    annot_dock.start_bx.setValue(6)
+    annot_dock.start_bx.editingFinished.emit()
+    assert fig.msg_box.isVisible()
+    assert fig.msg_box.informativeText() == 'Start can\'t be bigger or ' \
+                                            'equal to Stop!'
+    fig.msg_box.close()

--- a/mne_qt_browser/tests/test_pg_specific.py
+++ b/mne_qt_browser/tests/test_pg_specific.py
@@ -1,7 +1,12 @@
+# -*- coding: utf-8 -*-
+# Author: Martin Schulz <dev@earthman-music.de>
+#
+# License: BSD-3-Clause
+
 import numpy as np
 
 
-def test_annotations_interactions(raw_orig, browser_backend):
+def test_annotations_interactions(raw_orig, pg_backend):
     """Test interactions specific to pyqtgraph-backend."""
     # Add test-annotations
     onsets = np.arange(2, 8, 2) + raw_orig.first_time
@@ -69,10 +74,10 @@ def test_annotations_interactions(raw_orig, browser_backend):
     assert raw_orig.annotations.onset[0] == 1.5 + raw_orig.first_time
     assert raw_orig.annotations.duration[0] == 2.
 
-    # # Test SpinBox Warning
-    # annot_dock.start_bx.setValue(6)
-    # annot_dock.start_bx.editingFinished.emit()
-    # assert fig.msg_box.isVisible()
-    # assert fig.msg_box.informativeText() == 'Start can\'t be bigger or ' \
-    #                                         'equal to Stop!'
-    # fig.msg_box.close()
+    # Test SpinBox Warning
+    annot_dock.start_bx.setValue(6)
+    annot_dock.start_bx.editingFinished.emit()
+    assert fig.msg_box.isVisible()
+    assert fig.msg_box.informativeText() == 'Start can\'t be bigger or ' \
+                                            'equal to Stop!'
+    fig.msg_box.close()

--- a/mne_qt_browser/tests/test_pg_specific.py
+++ b/mne_qt_browser/tests/test_pg_specific.py
@@ -69,10 +69,10 @@ def test_annotations_interactions(raw_orig, browser_backend):
     assert raw_orig.annotations.onset[0] == 1.5 + raw_orig.first_time
     assert raw_orig.annotations.duration[0] == 2.
 
-    # Test SpinBox Warning
-    annot_dock.start_bx.setValue(6)
-    annot_dock.start_bx.editingFinished.emit()
-    assert fig.msg_box.isVisible()
-    assert fig.msg_box.informativeText() == 'Start can\'t be bigger or ' \
-                                            'equal to Stop!'
-    fig.msg_box.close()
+    # # Test SpinBox Warning
+    # annot_dock.start_bx.setValue(6)
+    # annot_dock.start_bx.editingFinished.emit()
+    # assert fig.msg_box.isVisible()
+    # assert fig.msg_box.informativeText() == 'Start can\'t be bigger or ' \
+    #                                         'equal to Stop!'
+    # fig.msg_box.close()

--- a/mne_qt_browser/tests/test_speed.py
+++ b/mne_qt_browser/tests/test_speed.py
@@ -134,7 +134,7 @@ def test_scroll_speed_raw(raw_orig, benchmark_param, store,
                         show=False, block=False, **benchmark_param)
 
     # # Wait max. 10 s for precomputed data to load
-    if fig.mne.precompute:
+    if fig.load_thread is not None:
         fig.load_thread.wait(10000)
 
     timer = QTimer()
@@ -177,7 +177,7 @@ def test_scroll_speed_epochs(raw_orig, benchmark_param, store,
     fig = epochs.plot(show=False, block=False, **benchmark_param)
 
     # # Wait max. 10 s for precomputed data to load
-    if fig.mne.precompute:
+    if fig.load_thread is not None:
         fig.load_thread.wait(10000)
 
     timer = QTimer()

--- a/mne_qt_browser/tests/test_speed.py
+++ b/mne_qt_browser/tests/test_speed.py
@@ -134,7 +134,7 @@ def test_scroll_speed_raw(raw_orig, benchmark_param, store,
                         show=False, block=False, **benchmark_param)
 
     # # Wait max. 10 s for precomputed data to load
-    if fig.load_thread is not None:
+    if fig.load_thread.isRunning():
         fig.load_thread.wait(10000)
 
     timer = QTimer()
@@ -177,7 +177,7 @@ def test_scroll_speed_epochs(raw_orig, benchmark_param, store,
     fig = epochs.plot(show=False, block=False, **benchmark_param)
 
     # # Wait max. 10 s for precomputed data to load
-    if fig.load_thread is not None:
+    if fig.load_thread.isRunning():
         fig.load_thread.wait(10000)
 
     timer = QTimer()

--- a/mne_qt_browser/tests/test_speed.py
+++ b/mne_qt_browser/tests/test_speed.py
@@ -108,7 +108,9 @@ def _initiate_hscroll(pg_fig, store, request, timer):
 
         h_mean_fps = 1 / np.median(hscroll_diffs)
         v_mean_fps = 1 / np.median(vscroll_diffs)
-        store[request.node.callspec.id] = dict(h=h_mean_fps, v=v_mean_fps)
+        type_key = 'Epochs' if pg_fig.mne.is_epochs else 'Raw'
+        store[type_key][request.node.callspec.id] = dict(h=h_mean_fps,
+                                                         v=v_mean_fps)
         pg_fig.close()
 
 

--- a/mne_qt_browser/tests/test_speed.py
+++ b/mne_qt_browser/tests/test_speed.py
@@ -173,8 +173,25 @@ def test_scroll_speed_epochs(raw_orig, benchmark_param, store,
     events = np.full((50, 3), [0, 0, 1])
     events[:, 0] = np.arange(0, len(raw_orig), len(raw_orig) / 50) \
         + raw_orig.first_samp
-    epochs = mne.Epochs(raw_orig, events)
-    fig = epochs.plot(show=False, block=False, **benchmark_param)
+    epochs = mne.Epochs(raw_orig, events, preload=True)
+    # Prevent problems with info's locked-stated
+    epochs.info._unlocked = True
+    # Make colored segments (simulating bad epochs,
+    # bad segments from autoreject)
+    epoch_col1 = np.asarray(['b'] * len(epochs.ch_names))
+    epoch_col1[::2] = 'r'
+    epoch_col2 = np.asarray(['r'] * len(epochs.ch_names))
+    epoch_col2[::2] = 'b'
+    epoch_col3 = np.asarray(['g'] * len(epochs.ch_names))
+    epoch_col3[::2] = 'b'
+    epoch_colors = np.asarray([['b'] * len(epochs.ch_names) for _ in
+                               range(len(epochs))])
+    epoch_colors[::3] = epoch_col1
+    epoch_colors[1::3] = epoch_col2
+    epoch_colors[2::3] = epoch_col3
+    epoch_colors = epoch_colors.tolist()
+    fig = epochs.plot(show=False, block=False, epoch_colors=epoch_colors,
+                      **benchmark_param)
 
     # # Wait max. 10 s for precomputed data to load
     if fig.load_thread.isRunning():

--- a/mne_qt_browser/tests/test_speed.py
+++ b/mne_qt_browser/tests/test_speed.py
@@ -12,7 +12,6 @@ from time import perf_counter
 import numpy as np
 import pytest
 from PyQt5.QtCore import QTimer
-from PyQt5.QtTest import QTest
 from PyQt5.QtWidgets import QApplication
 
 import mne
@@ -134,10 +133,9 @@ def test_scroll_speed_raw(raw_orig, benchmark_param, store,
     fig = raw_orig.plot(duration=5, n_channels=40,
                         show=False, block=False, **benchmark_param)
 
-    # # Wait for precomputed data to load
-    # if fig.mne.precompute:
-    #     while not fig.mne.data_precomputed:
-    #         QTest.qWait(100)
+    # # Wait max. 10 s for precomputed data to load
+    if fig.mne.precompute:
+        fig.load_thread.wait(10000)
 
     timer = QTimer()
     timer.timeout.connect(partial(_initiate_hscroll, fig, store,
@@ -178,10 +176,9 @@ def test_scroll_speed_epochs(raw_orig, benchmark_param, store,
     epochs = mne.Epochs(raw_orig, events)
     fig = epochs.plot(show=False, block=False, **benchmark_param)
 
-    # # Wait for precomputed data to load
-    # if fig.mne.precompute:
-    #     while not fig.mne.data_precomputed:
-    #         QTest.qWait(100)
+    # # Wait max. 10 s for precomputed data to load
+    if fig.mne.precompute:
+        fig.load_thread.wait(10000)
 
     timer = QTimer()
     timer.timeout.connect(partial(_initiate_hscroll, fig, store,

--- a/mne_qt_browser/tests/test_speed.py
+++ b/mne_qt_browser/tests/test_speed.py
@@ -100,11 +100,6 @@ def _initiate_hscroll(pg_fig, store, request, timer):
         v_last_time = now
     else:
         timer.stop()
-        bm_count = copy(bm_limit)
-        hscroll_dir = True
-        vscroll_dir = True
-        h_last_time = None
-        v_last_time = None
 
         h_mean_fps = 1 / np.median(hscroll_diffs)
         v_mean_fps = 1 / np.median(vscroll_diffs)
@@ -139,10 +134,10 @@ def test_scroll_speed_raw(raw_orig, benchmark_param, store,
     fig = raw_orig.plot(duration=5, n_channels=40,
                         show=False, block=False, **benchmark_param)
 
-    # Wait for precomputed data to load
-    if fig.mne.precompute:
-        while not fig.mne.data_precomputed:
-            QTest.qWait(100)
+    # # Wait for precomputed data to load
+    # if fig.mne.precompute:
+    #     while not fig.mne.data_precomputed:
+    #         QTest.qWait(100)
 
     timer = QTimer()
     timer.timeout.connect(partial(_initiate_hscroll, fig, store,
@@ -183,10 +178,10 @@ def test_scroll_speed_epochs(raw_orig, benchmark_param, store,
     epochs = mne.Epochs(raw_orig, events)
     fig = epochs.plot(show=False, block=False, **benchmark_param)
 
-    # Wait for precomputed data to load
-    if fig.mne.precompute:
-        while not fig.mne.data_precomputed:
-            QTest.qWait(100)
+    # # Wait for precomputed data to load
+    # if fig.mne.precompute:
+    #     while not fig.mne.data_precomputed:
+    #         QTest.qWait(100)
 
     timer = QTimer()
     timer.timeout.connect(partial(_initiate_hscroll, fig, store,

--- a/mne_qt_browser/tests/test_speed.py
+++ b/mne_qt_browser/tests/test_speed.py
@@ -190,6 +190,10 @@ def test_scroll_speed_epochs(raw_orig, benchmark_param, store,
     epoch_colors[1::3] = epoch_col2
     epoch_colors[2::3] = epoch_col3
     epoch_colors = epoch_colors.tolist()
+
+    if sys.platform == 'darwin':
+        benchmark_param['use_opengl'] = True
+
     fig = epochs.plot(show=False, block=False, epoch_colors=epoch_colors,
                       **benchmark_param)
 


### PR DESCRIPTION
## Description
This is work in progress for epochs support.

- [x] adapt pyqtgraph-backend to IO for Epochs from mpl-backend
- [x] handle visualization
- [x] handle epochs-specific interaction (selecting bad epochs, etc.)
- [x] let pyqtgraph-backend pass `mne.viz.tests.test_epochs.py`

This PR depends on a [correspondent PR](https://github.com/mne-tools/mne-python/pull/10297) in mne-python.

<details>
<summary>Code I currently use for testing</summary>

```python
import mne
import os
import numpy as np

from mne.viz import use_browser_backend

# Load Raw
sample_data_folder = mne.datasets.sample.data_path()
raw_file = os.path.join(sample_data_folder, 'MEG', 'sample',
                        'sample_audvis_raw.fif')
raw = mne.io.read_raw(raw_file)

# Load Events
events_path = os.path.join(sample_data_folder, 'MEG', 'sample',
                           'sample_audvis_raw-eve.fif')
events = mne.read_events(events_path)

# Add test-annotations
onsets = np.arange(2, 8, 2) + raw.first_time
durations = np.repeat(1, len(onsets))
descriptions = ['Test1', 'Test2', 'Test3']
for onset, duration, description in zip(onsets, durations, descriptions):
    raw.annotations.append(onset, duration, description)

epo = mne.Epochs(raw, events)

epoch_col1 = np.asarray(['b'] * len(epo.ch_names))
epoch_col1[::2] = 'r'
epoch_col2 = np.asarray(['r'] * len(epo.ch_names))
epoch_col2[::2] = 'b'
epoch_col3 = np.asarray(['g'] * len(epo.ch_names))
epoch_col3[::2] = 'b'
epoch_colors = np.asarray([['b'] * len(epo.ch_names) for _ in
                           range(len(epo.events))])
epoch_colors[::3] = epoch_col1
epoch_colors[1::3] = epoch_col2
epoch_colors[2::3] = epoch_col3
epoch_colors = epoch_colors.tolist()

with use_browser_backend('pyqtgraph'):
    epo.plot(block=True, n_epochs=10, events=events, epoch_colors=epoch_colors,
             precompute=False)
```
</details>

**REMINDER**: CI testing with the PR branch from mne-tools/mne-python#10297 has to be reverted before merging!