### PR TITLE
MNT: Add PR-Template and CONTRIBUTING.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+Thanks for contributing a pull request! Please make sure you have read the
+[contribution guidelines](https://mne.tools/dev/install/contributing.html)
+before submitting.
+
+Please be aware that we are a loose team of volunteers so patience is
+necessary. Assistance handling other issues is very welcome. We value all user
+contributions, no matter how minor they are. If we are slow to review, either
+the pull request needs some benchmarking, tinkering, convincing, etc. or more
+likely the reviewers are simply busy. In either case, we ask for your
+understanding during the review process.
+
+Again, thanks for contributing!
+
+#### Reference issue
+
+Example: Fixes #1234.
+
+#### What does this implement/fix?
+
+Explain your changes.
+
+#### Additional information
+
+Any additional information you think is important.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,0 @@
-# Changelog
-
-## main
-
-## v0.1.1
-- Fix keyboard-focus bug from #10
-
-## v0.1.0
-- First stable release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing to mne-qt-browser
+
+**Thank you very much for taking the time to contribute!** :+1::+1::+1:
+
+As this package is a subsidiarian of [MNE-Python](https://mne.tools/dev/index.html)
+its [guidelines](https://github.com/mne-tools/mne-python) for contributing apply as well.
+
+## Setting up development environment
+Follow the [instructions from mne-python](https://mne.tools/dev/install/contributing.html#setting-up-your-local-development-environment)
+and additionally install the dependencies for this repository:
+
+```
+pip install -r requirements_testing.txt
+```


### PR DESCRIPTION
This adds the same PR-template as for mne-python (since the contribution guide applies for mne-qt-browser as well) and adds a CONTRIBUTING.md.