### PR TITLE
MNT: Downgrade pytest to pass tests with maint/0.24

### DIFF
--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -73,6 +73,9 @@ jobs:
           git clone -b ${MNE_BRANCH} --single-branch --depth=1 https://github.com/mne-tools/mne-python.git ../mne-python
           python -m pip install -qe ../mne-python
           python -m pip install -ve .${PIP_OPTION} -r requirements.txt -r requirements_testing.txt
+      - name: Downgrade pytest for mne==0.24
+        run: python -m pip install pytest==6.2.5
+        if: ${MNE_BRANCH} == 'maint/0.24'
       - shell: bash -el {0}
         run: ./tools/get_testing_version.sh
         name: 'Get testing version'

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -75,7 +75,7 @@ jobs:
           python -m pip install -ve .${PIP_OPTION} -r requirements.txt -r requirements_testing.txt
       - name: Downgrade pytest for mne==0.24
         run: python -m pip install pytest==6.2.5
-        if: ${MNE_BRANCH} == 'maint/0.24'
+        if: ${{ matrix.mne }} == 'maint/0.24'
       - shell: bash -el {0}
         run: ./tools/get_testing_version.sh
         name: 'Get testing version'


### PR DESCRIPTION
This PR avoids all CIs to fail for the branch `maint/0.24` from mne-python by setting `pytest==6.2.5`.
The cause is a `DeprecationError` which is fixed in mne-tools/mne-python#10120.