### PR TITLE
BUG: Set background-color with bgcolor

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -2282,8 +2282,9 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
                 logger.info(
                     f'Using pyopengl with version {OpenGL.__version__}')
         # Initialize BrowserView (inherits QGraphicsView)
-        view = BrowserView(plt, background='w',
-                           useOpenGL=self.mne.use_opengl)
+        view = BrowserView(plt, useOpenGL=self.mne.use_opengl)
+        if hasattr(self.mne, 'bgcolor'):
+            view.setBackground(_get_color(self.mne.bgcolor))
         layout.addWidget(view, 0, 0)
 
         # Initialize Scroll-Bars


### PR DESCRIPTION
## Description
As in mne-tools/mne-python#10317, the parameter `bgcolor` has not been considered to set the background-color of the plot.
This is now fixed and fixes #50.