### PR TITLE
FIX: Fixes

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -46,7 +46,6 @@ from mne.viz import plot_sensors
 from mne.viz._figure import BrowserBase
 from mne.viz.utils import _simplify_float, _merge_annotations, _figure_agg
 from mne.annotations import _sync_onset
-from mne.io import BaseRaw
 from mne.io.pick import (_DATA_CH_TYPES_ORDER_DEFAULT,
                          channel_indices_by_type, _DATA_CH_TYPES_SPLIT)
 from mne.utils import _to_rgb, logger, sizeof_fmt, warn, get_config


### PR DESCRIPTION
1. `orig_format` doesn't exist for Epochs/ICA, assume float32
2. `lasso_event` is not a real matplotlib event, let's just make our own `callbacks` and use them (this is in https://github.com/mne-tools/mne-python/pull/9960 but has a backward compat shim here)
3. When I did `group_by='selection'`, I actually had a matplotlib Qt window show up even though `show=False` was used in `plot_sensors`. A cleaner approach I think is just to explicitly use an Agg figure