### PR TITLE
MAINT: Change name

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -2611,7 +2611,7 @@ def _disconnect(sig):
         pass
 
 
-class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
+class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
     """A PyQtGraph-backend for 2D data browsing."""
 
     gotClosed = pyqtSignal()
@@ -4513,7 +4513,7 @@ class PyQtGraphBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
             _browser_instances.remove(self)
         self._close(event)
         self.gotClosed.emit()
-        # Make sure PyQtBrowser gets deleted after it was closed.
+        # Make sure it gets deleted after it was closed.
         self.deleteLater()
 
 
@@ -4594,6 +4594,10 @@ def _init_browser(**kwargs):
     out = _init_mne_qtapp(pg_app=True, **app_kwargs)
     if 'splash' in app_kwargs:
         kwargs['splash'] = out[1]  # returned as secord element
-    browser = PyQtGraphBrowser(**kwargs)
+    browser = MNEQtBrowser(**kwargs)
 
     return browser
+
+
+class PyQtGraphBrowser(MNEQtBrowser):
+    pass  # just for backward compat with MNE 1.0 scraping

--- a/mne_qt_browser/figure.py
+++ b/mne_qt_browser/figure.py
@@ -1,0 +1,1 @@
+from ._pg_figure import MNEQtBrowser  # noqa


### PR DESCRIPTION
To fix https://github.com/mne-tools/mne-qt-browser/issues/77, we're going to want to publicly document what object from this package `add_figure` can operate on, and (same thing) what gets returned by `raw.plot`. Currently this would be `mne_qt_browser._pg_figure.PyQtGraphBrowser`. This PR changes it so that we can call it `mne_qt_browser.figure.MNEQtBrowser`, which is a bit verbose, but at least is clearly in a a public namespace and reflects how we now think about this browser (less about pyqtgraph, more about a native Qt browser that happens to use PyQtGraph for speed).