### PR TITLE
Fix x axis label text for Epochs (it used to say Time)

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -3207,6 +3207,9 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
                 'qt_key': Qt.Key_Space
             }
         }
+        if self.mne.is_epochs:
+            # Disable time format toggling
+            del self.mne.keyboard_shortcuts['t']
 
     def _update_yaxis_labels(self):
         self.mne.channel_axis.repaint()
@@ -4195,12 +4198,9 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
             self._set_events_visible(self.mne.events_visible)
 
     def _toggle_time_format(self):
-        if self.mne.is_epochs:  # no-op
-            return
-
         if self.mne.time_format == 'float':
             self.mne.time_format = 'clock'
-            self.mne.time_axis.setLabel(text='Time')
+            self.mne.time_axis.setLabel(text='Time of day')
         else:
             self.mne.time_format = 'float'
             self.mne.time_axis.setLabel(text='Time', units='s')

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -4195,6 +4195,9 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
             self._set_events_visible(self.mne.events_visible)
 
     def _toggle_time_format(self):
+        if self.mne.is_epochs:  # no-op
+            return
+
         if self.mne.time_format == 'float':
             self.mne.time_format = 'clock'
             self.mne.time_axis.setLabel(text='Time')

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -2752,7 +2752,11 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
 
         # Initialize Axis-Items
         self.mne.time_axis = TimeAxis(self.mne)
-        self.mne.time_axis.setLabel(text='Time', units='s')
+        if self.mne.is_epochs:
+            self.mne.time_axis.setLabel(text='Epoch Index', units=None)
+        else:
+            self.mne.time_axis.setLabel(text='Time', units='s')
+
         self.mne.channel_axis = ChannelAxis(self)
         self.mne.viewbox = RawViewBox(self)
 


### PR DESCRIPTION
The text alignment is still wrong for me but at least the text itself is now correct for Epochs…

<img width="448" alt="Screen Shot 2022-04-05 at 15 32 40" src="https://user-images.githubusercontent.com/2046265/161765496-6b6d843b-5b80-4084-9d88-1fc253d5c8cf.png">
