### PR TITLE
Make MEG channel order in butterfly plot match order in overview bar

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -69,6 +69,12 @@ except ImportError:
 
 name = 'pyqtgraph'
 
+# MNE's butterfly plots traditionally default to the channel ordering of
+# mag, grad, ..., which is inconsistent with the order in non-butterfly mode
+# and hence doesn't match the order in the overview bar either. So we swap
+# grads and mags here.
+DATA_CH_TYPES_ORDER = ('grad', 'mag', *_DATA_CH_TYPES_ORDER_DEFAULT[2:])
+
 # This can be removed when mne==1.0 is released.
 try:
     from mne.viz.backends._utils import _init_mne_qtapp
@@ -552,10 +558,10 @@ class ChannelAxis(AxisItem):
         if self.mne.butterfly and self.mne.fig_selection is not None:
             tick_strings = list(self.main._make_butterfly_selections_dict())
         elif self.mne.butterfly:
-            _, ixs, _ = np.intersect1d(_DATA_CH_TYPES_ORDER_DEFAULT,
+            _, ixs, _ = np.intersect1d(DATA_CH_TYPES_ORDER,
                                        self.mne.ch_types, return_indices=True)
             ixs.sort()
-            tick_strings = np.array(_DATA_CH_TYPES_ORDER_DEFAULT)[ixs]
+            tick_strings = np.array(DATA_CH_TYPES_ORDER)[ixs]
         else:
             # Get channel-names and by substracting 1 from tick-values
             # since the first channel starts at y=1.
@@ -2678,7 +2684,7 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
         self.mne.scale_factor = 1
         # Stores channel-types for butterfly-mode
         self.mne.butterfly_type_order = [tp for tp in
-                                         _DATA_CH_TYPES_ORDER_DEFAULT
+                                         DATA_CH_TYPES_ORDER
                                          if tp in self.mne.ch_types]
         if self.mne.is_epochs:
             # Stores parameters for epochs


### PR DESCRIPTION
Fixes #94


MWE:
```python
# %%
import mne


sample_dir = mne.datasets.sample.data_path()
sample_fname = sample_dir / 'MEG' / 'sample' / 'sample_audvis_raw.fif'

raw = mne.io.read_raw_fif(sample_fname, preload=True)
raw.crop(tmax=60)
raw.plot(block=True, butterfly=True)
```

| before | after |
|----|---|
| <img width="1138" alt="Screen Shot 2022-04-05 at 20 10 10" src="https://user-images.githubusercontent.com/2046265/161821946-61d16f13-5d5b-476a-8789-ff40682cd432.png"> | <img width="1138" alt="Screen Shot 2022-04-05 at 20 09 56" src="https://user-images.githubusercontent.com/2046265/161821970-356e4aa8-5997-49d4-95ec-0606c94825e3.png"> |


cc @agramfort 