### PR TITLE
CI: Bump to maint/1.0

### DIFF
--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -29,9 +29,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, windows, macos]
-        mne: [main, maint/0.24]
+        mne: [main, maint/1.0]
         opengl: ['[opengl]']
-        python: ['3.9']
+        python: ['3.10']
         name: [matrix]
         include:
           - os: ubuntu
@@ -45,10 +45,15 @@ jobs:
             python: '3.9'
             name: no opengl
           - os: ubuntu
-            mne: maint/0.24
+            mne: maint/1.0
             opengl: ''
             python: '3.9'
             name: no opengl
+          - os: ubuntu
+            mne: maint/0.24
+            opengl: '[opengl]'
+            python: '3.9'
+            name: old
     name: pytest ${{ matrix.name }} / ${{ matrix.os }} / MNE ${{ matrix.mne }}
     runs-on: ${{ matrix.os }}-latest
     env:


### PR DESCRIPTION
Bump to use maint/1.0 of MNE, but keep one 0.24 build around. If it's not too painful to maintain backward compat to two versions, I think we should.

Also attempts to bump the main build matrix to 3.10, let's see if it works.