### PR TITLE
BUG: Fix the pixel ratio

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -2637,12 +2637,11 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
         QApplication.processEvents()  # needs to happen for the theme to be set
 
         # HiDPI stuff
-        desktop = QApplication.desktop()
-        dpi_ratio = desktop.physicalDpiY() / desktop.logicalDpiY()
-        logger.debug(f'Desktop DPI ratio: {dpi_ratio:0.3f}')
+        pixel_ratio = self.devicePixelRatio()
+        logger.debug(f'Desktop pixel ratio: {pixel_ratio:0.3f}')
 
         def _hidpi_mkPen(*args, **kwargs):
-            kwargs['width'] = dpi_ratio * kwargs.get('width', 1.)
+            kwargs['width'] = pixel_ratio * kwargs.get('width', 1.)
             return mkPen(*args, **kwargs)
 
         self.mne.mkPen = _hidpi_mkPen


### PR DESCRIPTION
Directly use the `devicePixelRatio` instead of the (incorrect) self-computation. On my system the old value was ~1.7 now it's the correct 2.

@hoechenberger feel free to review/merge if you're happy