### PR TITLE
CI: Dont run benchmarks on macOS

### DIFF
--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -117,8 +117,10 @@ jobs:
         name: Run MNE-Tests
       - run: pytest mne_qt_browser/tests/test_pg_specific.py
         name: Run pyqtgraph-specific tests
+      # These are slow on macOS, so skip them
       - run: pytest mne_qt_browser/tests/test_speed.py
         name: Run benchmarks
+        if: runner.os != 'macOS'
       - uses: codecov/codecov-action@v1
         if: always()
         name: 'Upload coverage to CodeCov'


### PR DESCRIPTION
Looking at CIs I noticed that macOS takes ~5 minutes longer than the other CIs. It turns out this is also about how long it takes to run benchmarks on there. It seems a bit overkill to run them with every PR on every platform, so let's just disable them on macOS for now.