### PR TITLE
Add theme related req to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,12 @@
 numpy
 scipy
 matplotlib
-mne
+PyQt5>=5.12
 qtpy
 scooby
-PyQt5
-pyqtgraph
+qtpy
+pyqtgraph>=0.12.3
+colorspacious
 pyopengl; platform_system=="Darwin"
 darkdetect
 qdarkstyle

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ PyQt5>=5.12
 qtpy
 scooby
 qtpy
+mne>=0.24
 pyqtgraph>=0.12.3
 colorspacious
 pyopengl; platform_system=="Darwin"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ scooby
 PyQt5
 pyqtgraph
 pyopengl; platform_system=="Darwin"
+darkdetect
+qdarkstyle

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ matplotlib
 PyQt5>=5.12
 qtpy
 scooby
-qtpy
 mne>=0.24
 pyqtgraph>=0.12.3
 colorspacious

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ def parse_requirements_file(fname):
             requirements.append(req)
     return requirements
 
+
 readme = (pathlib.Path(__file__).parent / "README.md").read_text()
 
 version = None

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,19 @@ import pathlib
 
 from setuptools import setup
 
+
+def parse_requirements_file(fname):
+    requirements = list()
+    with open(fname, 'r') as fid:
+        for line in fid:
+            req = line.strip()
+            if req.startswith('#'):
+                continue
+            # strip end-of-line comments
+            req = req.split('#', maxsplit=1)[0].strip()
+            requirements.append(req)
+    return requirements
+
 readme = (pathlib.Path(__file__).parent / "README.md").read_text()
 
 version = None
@@ -32,19 +45,7 @@ setup(name='mne-qt-browser',
                    'Operating System :: OS Independent'],
       packages=['mne_qt_browser'],
       include_package_data=True,
-      install_requires=['numpy',
-                        'scipy',
-                        'matplotlib',
-                        'PyQt5>=5.12',
-                        'qtpy',
-                        'scooby',
-                        'mne>=0.24',
-                        'pyqtgraph>=0.12.3',
-                        'colorspacious',
-                        'pyopengl; platform_system=="Darwin"',
-                        'darkdetect',
-                        'qdarkstyle',
-                        ],
+      install_requires=parse_requirements_file('requirements.txt'),
       extras_require={
           'opengl': ['pyopengl'],
       },

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,8 @@ setup(name='mne-qt-browser',
                         'pyqtgraph>=0.12.3',
                         'colorspacious',
                         'pyopengl; platform_system=="Darwin"',
+                        'darkdetect',
+                        'qdarkstyle',
                         ],
       extras_require={
           'opengl': ['pyopengl'],


### PR DESCRIPTION
`darkdetect` and `qdarkstyle` are 2 optional dependencies for theme management.
I think they are used by `mne-python` before invoking the browser, but since theme selection is a key feature of the browser, how about adding them as a requirement here as well? This way, a base install of `mne` will include them by default. 

If they are used by other GUI through `mne-python`, then maybe it would be worth adding them to one of the `requirements_extra.txt` of `mne-python` as well. 