### PR TITLE
MAINT: Bump version for release

### DIFF
--- a/mne_qt_browser/_version.py
+++ b/mne_qt_browser/_version.py
@@ -1,2 +1,2 @@
 """The version number."""
-__version__ = '0.2.7.dev0'
+__version__ = '0.3.0'


### PR DESCRIPTION
I think we should cut a release. Given that this will be the first to support Qt6, I bumped to 0.3.0 (last release was 0.2.6).

@agramfort or @hoechenberger feel free to merge and I'll cut a release