### PR TITLE
ENH: Respect activation

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+branch = True
+source = mne_qt_browser
+omit =
+    */setup.py
+    */mne_qt_browser/_fixes.py
+    */mne_qt_browser/conftest.py

--- a/mne_qt_browser/_fixes.py
+++ b/mne_qt_browser/_fixes.py
@@ -1,3 +1,16 @@
+# -*- coding: utf-8 -*-
+"""Backports for MNE versions (mostly)."""
+
+# Author: Martin Schulz <dev@earthman-music.de>
+#
+# License: BSD-3-Clause
+
+from contextlib import contextmanager
+import platform
+import sys
+
+from mne.utils import logger
+
 ###############################################################################
 # MNE 1.0+
 try:

--- a/mne_qt_browser/_fixes.py
+++ b/mne_qt_browser/_fixes.py
@@ -1,0 +1,84 @@
+###############################################################################
+# MNE 1.0+
+try:
+    from mne.viz.backends._utils import _qt_raise_window
+except ImportError:
+    def _qt_raise_window(win):
+        try:
+            from matplotlib import rcParams
+            raise_window = rcParams['figure.raise_window']
+        except ImportError:
+            raise_window = True
+        if raise_window:
+            win.activateWindow()
+            win.raise_()
+
+try:
+    from mne.viz.backends._utils import _init_mne_qtapp
+except ImportError:
+    from mne.viz.backends._utils import _init_qt_resources
+
+    def _init_mne_qtapp(enable_icon=True, pg_app=False):
+        """Get QApplication-instance for MNE-Python.
+
+        Parameter
+        ---------
+        enable_icon: bool
+            If to set an MNE-icon for the app.
+        pg_app: bool
+            If to create the QApplication with pyqtgraph. For an until know
+            undiscovered reason the pyqtgraph-browser won't show without
+            mkQApp from pyqtgraph.
+
+        Returns
+        -------
+        app: ``qtpy.QtWidgets.QApplication``
+            Instance of QApplication.
+        """
+        from qtpy.QtWidgets import QApplication
+        from qtpy.QtGui import QIcon
+
+        app_name = 'MNE-Python'
+        organization_name = 'MNE'
+
+        # Fix from cbrnr/mnelab for app name in menu bar
+        if sys.platform.startswith("darwin"):
+            try:
+                # set bundle name on macOS (app name shown in the menu bar)
+                from Foundation import NSBundle
+                bundle = NSBundle.mainBundle()
+                info = (bundle.localizedInfoDictionary()
+                        or bundle.infoDictionary())
+                info["CFBundleName"] = app_name
+            except ModuleNotFoundError:
+                pass
+
+        if pg_app:
+            from pyqtgraph import mkQApp
+            app = mkQApp(app_name)
+        else:
+            app = (QApplication.instance()
+                   or QApplication(sys.argv or [app_name]))
+            app.setApplicationName(app_name)
+        app.setOrganizationName(organization_name)
+
+        if enable_icon:
+            # Set icon
+            _init_qt_resources()
+            kind = 'bigsur-' if platform.mac_ver()[0] >= '10.16' else ''
+            app.setWindowIcon(QIcon(f":/mne-{kind}icon.png"))
+
+        return app
+
+###############################################################################
+# pytestqt
+try:
+    from pytestqt.exceptions import capture_exceptions
+except ImportError:
+    logger.debug('If pytest-qt is not installed, the errors from inside '
+                 'the Qt-loop will be occluded and it will be harder '
+                 'to trace back the cause.')
+
+    @contextmanager
+    def capture_exceptions():
+        yield []

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -1497,7 +1497,6 @@ class _BaseDialog(QDialog):
         self.modal = modal
 
         self.setAttribute(Qt.WA_DeleteOnClose, True)
-        self.setAttribute(Qt.WA_MacAlwaysShowToolWindow, True)
 
         self.mne.child_figs.append(self)
 

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -1497,6 +1497,7 @@ class _BaseDialog(QDialog):
         self.modal = modal
 
         self.setAttribute(Qt.WA_DeleteOnClose, True)
+        self.setAttribute(Qt.WA_MacAlwaysShowToolWindow, True)
 
         self.mne.child_figs.append(self)
 
@@ -2684,7 +2685,6 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
 
         # control raising with _qt_raise_window
         self.setAttribute(Qt.WA_ShowWithoutActivating, True)
-        self.setAttribute(Qt.WA_MacAlwaysShowToolWindow, True)
 
         # Initialize attributes which are only used by pyqtgraph, not by
         # matplotlib and add them to MNEBrowseParams.

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -14,7 +14,6 @@ import sys
 from pathlib import Path
 from ast import literal_eval
 from collections import OrderedDict
-from contextlib import contextmanager
 from copy import copy
 from functools import partial
 from os.path import getsize
@@ -1538,6 +1537,14 @@ class _BaseDialog(QDialog):
             if self in self.mne.child_figs:
                 self.mne.child_figs.remove(self)
         event.accept()
+
+    # If this widget gets activated (e.g., the user clicks away from the
+    # browser but then returns to it by clicking in a selection window),
+    # the main window should be raised as well
+    def event(self, event):
+        if event.type() == QEvent.WindowActivate:
+            self.main.raise_()
+        return super().event(event)
 
 
 class SettingsDialog(_BaseDialog):

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -2684,6 +2684,7 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
 
         # control raising with _qt_raise_window
         self.setAttribute(Qt.WA_ShowWithoutActivating, True)
+        self.setAttribute(Qt.WA_MacAlwaysShowToolWindow, True)
 
         # Initialize attributes which are only used by pyqtgraph, not by
         # matplotlib and add them to MNEBrowseParams.


### PR DESCRIPTION
1. Allow `_qt_raise_window` to actually control window-raising behavior
2. If you click away from mne-qt-browser, then back to it using a child dialog, the main window should be raised. This can be tested locally with:
    ```
    import mne
    raw = mne.io.read_raw_fif(mne.datasets.sample.data_path() / 'MEG' / 'sample' / 'sample_audvis_raw.fif')
    raw.plot(group_by='selection', block=True)
    ```
3. Move backported functionality to `mne_qt_browser/_fixes.py`
4. No need to `self.mne.splash.close()` in `show` as this will be handled already by `_safe_splash`