### PR TITLE
fix lasso

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -1752,8 +1752,9 @@ class ProjDialog(_BaseDialog):
 
 
 class _ChannelFig(FigureCanvasQTAgg):
-    def __init__(self, figure):
+    def __init__(self, figure, mne):
         self.figure = figure
+        self.mne = mne
         super().__init__(figure)
         self.setFocusPolicy(Qt.FocusPolicy(Qt.StrongFocus | Qt.WheelFocus))
         self.setFocus()
@@ -1815,7 +1816,7 @@ class SelectionDialog(_BaseDialog):
             # MNE <= 0.24
             self.channel_fig.canvas.mpl_connect(
                 'lasso_event', self._set_custom_selection)
-        self.channel_widget = _ChannelFig(self.channel_fig)
+        self.channel_widget = _ChannelFig(self.channel_fig, self.mne)
         layout.addWidget(self.channel_widget)
 
         selections_dict = self.mne.ch_selections


### PR DESCRIPTION
#### What does this implement/fix?
This fixes the following error message when drawing a lasso in the selection-dialog.
`AttributeError: '_ChannelFig' object has no attribute 'mne'`

#### Steps to reproduce
`raw.plot(group_by='selection')`