### PR TITLE
BUG: Always newest xvfb-fix from mne

### DIFF
--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -100,7 +100,9 @@ jobs:
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
         name: Setup OpenGL on Windows
         if: runner.os == 'Windows'
-      - run: ./tools/setup_xvfb.sh
+      - run: |
+          curl --remote-name https://raw.githubusercontent.com/mne-tools/mne-python/main/tools/setup_xvfb.sh
+          bash setup_svfb.sh
         name: Setup xvfb on Linux
         working-directory: ../mne-python
         if: runner.os == 'Linux'

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -102,7 +102,7 @@ jobs:
         if: runner.os == 'Windows'
       - run: |
           curl --remote-name https://raw.githubusercontent.com/mne-tools/mne-python/main/tools/setup_xvfb.sh
-          bash setup_svfb.sh
+          bash setup_xvfb.sh
         name: Setup xvfb on Linux
         working-directory: ../mne-python
         if: runner.os == 'Linux'


### PR DESCRIPTION
#### What does this implement/fix?

This fixes failing maintenance-CIs for backwards-compatitibility. With mne<1.1, the CIs on `ubuntu-latest` fail, because a fix from mne-tools/mne-python#10923 hadn't been implemented then.
