### PR TITLE
BUG: (temporarily) fix MouseMove-Bug on windows

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -1065,7 +1065,7 @@ class OverviewBar(QGraphicsView):
         # is moved through the OverviewBar, even when now MouseBUtton is
         # pressed. Dragging the mouse on OverviewBar is then
         # not possible anymore.
-        if not sys.platform.startswith("win32"):
+        if not platform.system() == 'Windows':
             self._set_range_from_pos(event.pos())
 
     def _fit_bg_img(self):
@@ -2897,7 +2897,7 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
         if self.mne.use_opengl is None:  # default: opt-in
             # OpenGL needs to be enabled on macOS
             # (https://github.com/mne-tools/mne-qt-browser/issues/53)
-            default = 'true' if sys.platform == 'darwin' else ''
+            default = 'true' if platform.system() == 'Darwin' else ''
             config_val = get_config(opengl_key, default).lower()
             self.mne.use_opengl = (config_val == 'true')
 
@@ -2909,7 +2909,7 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
                 # it can lead to segfaults. If a user really knows what they
                 # are doing, they can pass use_opengl=False (or set
                 # MNE_BROWSER_USE_OPENGL=false)
-                if sys.platform == 'darwin':
+                if platform.system() == 'Darwin':
                     raise RuntimeError(
                         'Plotting on macOS without OpenGL may be unstable! '
                         'We recommend installing PyOpenGL, but it could not '

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -1059,7 +1059,14 @@ class OverviewBar(QGraphicsView):
 
     def mouseMoveEvent(self, event):
         """Customize mouse move events."""
-        self._set_range_from_pos(event.pos())
+        # This temporarily circumvents a bug, which only appears on windows
+        # and when pyqt>=5.14.2 is installed from conda-forge.
+        # It leads to receiving mouseMoveEvents all the time when the Mouse
+        # is moved through the OverviewBar, even when now MouseBUtton is
+        # pressed. Dragging the mouse on OverviewBar is then
+        # not possible anymore.
+        if not sys.platform.startswith("win32"):
+            self._set_range_from_pos(event.pos())
 
     def _fit_bg_img(self):
         # Remove previous item from scene


### PR DESCRIPTION
#### Reference issue
(Temporarily) fixes #137

#### What does this implement/fix?
This fixes a bug where the mouse movement is picked up from the overview-bar and the channel-selection-picker (`group_by='selection'`) always when the mouse is moved above and not only when a mouse-button is pressed.

This bug only seems to appear on Windows when pyqt>=5.15.4 is installed with conda. Since we didn't find a suitable fix yet, this PR disables dragging on the overviewbar on Windows until a better solution is found.