### PR TITLE
BUG: Fix ref bug using weakref

### DIFF
--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -199,7 +199,7 @@ jobs:
           mne sys_info -pd
           echo ${QT_LIB}:
           mne sys_info -pd | grep "^qtpy: .*{${QT_LIB}=.*}$"
-      - run: pytest -m pgtest --cov=mne_qt_browser --cov-report=xml ../mne-python/mne/viz
+      - run: pytest -m pgtest --cov=mne_qt_browser --cov-report=xml ../mne-python/mne/viz ../mne-python/mne/report
         name: Run MNE-Tests
       - run: pytest --error-for-skips mne_qt_browser/tests/test_pg_specific.py
         name: Run pyqtgraph-specific tests

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -78,7 +78,7 @@ jobs:
           set -e
           python -m pip install --upgrade pip
           # git clone -b ${MNE_BRANCH} --single-branch --depth=1 --branch main https://github.com/mne-tools/mne-python.git ../mne-python
-          git clone -b ${MNE_BRANCH} --single-branch --depth=1 --branch weak https://github.com/larsoner/mne-python.git ../mne-python
+          git clone -b ${MNE_BRANCH} --single-branch --depth=1 --branch check https://github.com/larsoner/mne-python.git ../mne-python
           python -m pip install -qe ../mne-python
           python -m pip install -ve .${PIP_OPTION} -r requirements.txt -r requirements_testing.txt PyQt5
       - name: Downgrade pytest for mne==0.24

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -77,8 +77,7 @@ jobs:
         run: |  # use MNE main to ensure test files are available
           set -e
           python -m pip install --upgrade pip
-          #git clone -b ${MNE_BRANCH} --single-branch --depth=1 --branch main https://github.com/mne-tools/mne-python.git ../mne-python
-          git clone -b ${MNE_BRANCH} --single-branch --depth=1 --branch check https://github.com/larsoner/mne-python.git ../mne-python
+          git clone -b ${MNE_BRANCH} --single-branch --depth=1 --branch main https://github.com/mne-tools/mne-python.git ../mne-python
           python -m pip install -qe ../mne-python
           python -m pip install -ve .${PIP_OPTION} -r requirements.txt -r requirements_testing.txt PyQt5
       - name: Downgrade pytest for mne==0.24
@@ -172,8 +171,7 @@ jobs:
         run: |  # use MNE main to ensure test files are available
           set -e
           python -m pip install --upgrade pip
-          #git clone -b ${MNE_BRANCH} --single-branch --depth=1 --branch main https://github.com/mne-tools/mne-python.git ../mne-python
-          git clone -b ${MNE_BRANCH} --single-branch --depth=1 --branch check https://github.com/larsoner/mne-python.git ../mne-python
+          git clone -b ${MNE_BRANCH} --single-branch --depth=1 --branch main https://github.com/mne-tools/mne-python.git ../mne-python
           python -m pip install -qe ../mne-python
           python -m pip install -ve .${PIP_OPTION} -r requirements.txt -r requirements_testing.txt $QT_LIB
       - shell: bash -el {0}

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -77,8 +77,7 @@ jobs:
         run: |  # use MNE main to ensure test files are available
           set -e
           python -m pip install --upgrade pip
-          # git clone -b ${MNE_BRANCH} --single-branch --depth=1 --branch main https://github.com/mne-tools/mne-python.git ../mne-python
-          git clone -b ${MNE_BRANCH} --single-branch --depth=1 --branch check https://github.com/larsoner/mne-python.git ../mne-python
+          git clone -b ${MNE_BRANCH} --single-branch --depth=1 --branch main https://github.com/mne-tools/mne-python.git ../mne-python
           python -m pip install -qe ../mne-python
           python -m pip install -ve .${PIP_OPTION} -r requirements.txt -r requirements_testing.txt PyQt5
       - name: Downgrade pytest for mne==0.24
@@ -116,7 +115,7 @@ jobs:
         if: runner.os == 'Linux' && contains(matrix.opengl, 'opengl')
       - name: Show system information
         run: mne sys_info
-      - run: pytest -m pgtest --cov=mne_qt_browser --cov-report=xml ../mne-python/mne/viz
+      - run: pytest -m pgtest --cov=mne_qt_browser --cov-report=xml ../mne-python/mne/viz ../mne-python/mne/report
         name: Run MNE-Tests
       - run: pytest --error-for-skips mne_qt_browser/tests/test_pg_specific.py
         name: Run pyqtgraph-specific tests

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -77,7 +77,8 @@ jobs:
         run: |  # use MNE main to ensure test files are available
           set -e
           python -m pip install --upgrade pip
-          git clone -b ${MNE_BRANCH} --single-branch --depth=1 https://github.com/mne-tools/mne-python.git ../mne-python
+          # git clone -b ${MNE_BRANCH} --single-branch --depth=1 --branch main https://github.com/mne-tools/mne-python.git ../mne-python
+          git clone -b ${MNE_BRANCH} --single-branch --depth=1 --branch weak https://github.com/larsoner/mne-python.git ../mne-python
           python -m pip install -qe ../mne-python
           python -m pip install -ve .${PIP_OPTION} -r requirements.txt -r requirements_testing.txt PyQt5
       - name: Downgrade pytest for mne==0.24

--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -77,7 +77,8 @@ jobs:
         run: |  # use MNE main to ensure test files are available
           set -e
           python -m pip install --upgrade pip
-          git clone -b ${MNE_BRANCH} --single-branch --depth=1 --branch main https://github.com/mne-tools/mne-python.git ../mne-python
+          #git clone -b ${MNE_BRANCH} --single-branch --depth=1 --branch main https://github.com/mne-tools/mne-python.git ../mne-python
+          git clone -b ${MNE_BRANCH} --single-branch --depth=1 --branch check https://github.com/larsoner/mne-python.git ../mne-python
           python -m pip install -qe ../mne-python
           python -m pip install -ve .${PIP_OPTION} -r requirements.txt -r requirements_testing.txt PyQt5
       - name: Downgrade pytest for mne==0.24
@@ -171,7 +172,8 @@ jobs:
         run: |  # use MNE main to ensure test files are available
           set -e
           python -m pip install --upgrade pip
-          git clone -b ${MNE_BRANCH} --single-branch --depth=1 https://github.com/mne-tools/mne-python.git ../mne-python
+          #git clone -b ${MNE_BRANCH} --single-branch --depth=1 --branch main https://github.com/mne-tools/mne-python.git ../mne-python
+          git clone -b ${MNE_BRANCH} --single-branch --depth=1 --branch check https://github.com/larsoner/mne-python.git ../mne-python
           python -m pip install -qe ../mne-python
           python -m pip install -ve .${PIP_OPTION} -r requirements.txt -r requirements_testing.txt $QT_LIB
       - shell: bash -el {0}

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -1977,10 +1977,9 @@ class SelectionDialog(_BaseDialog):
             self.channel_fig.lasso.callbacks.clear()
         for chkbx in self.chkbxs.values():
             _disconnect(chkbx.clicked, allow_error=True)
-        if hasattr(self, 'main'):
-            main = self.weakmain()
-            if main is not None:
-                main.close()
+        main = self.weakmain()
+        if main is not None:
+            main.close()
 
 
 class AnnotRegion(LinearRegionItem):

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -4352,7 +4352,7 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
                                  len(key_dict['parameter']) else 0)
                     val = key_dict['parameter'][param_idx]
                     if 'kw' in key_dict:
-                        slot(**{kw: val})
+                        slot(**{key_dict['kw']: val})
                     else:
                         slot(val)
                 else:

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -15,7 +15,6 @@ from pathlib import Path
 from ast import literal_eval
 from collections import OrderedDict
 from copy import copy
-from functools import partial
 from weakref import WeakMethod
 from os.path import getsize
 
@@ -1599,8 +1598,7 @@ class SettingsDialog(_BaseDialog):
         self.ds_method_cmbx.addItems(['subsample', 'mean', 'peak'])
         self.ds_method_cmbx.currentTextChanged.connect(
             _methpartial(self._value_changed, value_name='ds_method'))
-        self.ds_method_cmbx.setCurrentText(
-                self.mne.ds_method)
+        self.ds_method_cmbx.setCurrentText(self.mne.ds_method)
         layout.addRow('ds_method', self.ds_method_cmbx)
 
         self.scroll_sensitivity_slider = QSlider(Qt.Horizontal)
@@ -2321,9 +2319,10 @@ class AnnotationDock(QDockWidget):
         if ans == QMessageBox.Yes:
             self._remove_description(rm_description)
 
+    def _set_visible_region(self, state, *, description):
+        self.mne.visible_annotations[description] = bool(state)
+
     def _select_annotations(self):
-        def _set_visible_region(state, description):
-            self.mne.visible_annotations[description] = bool(state)
 
         def _select_all():
             for chkbx in chkbxs:
@@ -2346,8 +2345,8 @@ class AnnotationDock(QDockWidget):
         for des in self.mne.visible_annotations:
             chkbx = QCheckBox(des)
             chkbx.setChecked(self.mne.visible_annotations[des])
-            chkbx.stateChanged.connect(partial(_set_visible_region,
-                                               description=des))
+            chkbx.stateChanged.connect(
+                _methpartial(self._set_visible_region, description=des))
             chkbxs.append(chkbx)
             scroll_layout.addWidget(chkbx)
 

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from ast import literal_eval
 from collections import OrderedDict
 from copy import copy
+from functools import partial
 from os.path import getsize
 
 import numpy as np
@@ -2141,7 +2142,7 @@ def _select_all(chkbxs):
         chkbx.setChecked(True)
 
 
-def _clear_all(chekbxs):
+def _clear_all(chkbxs):
     for chkbx in chkbxs:
         chkbx.setChecked(False)
 
@@ -2251,7 +2252,8 @@ class AnnotationDock(QDockWidget):
             ed_region.update_description(new_des)
         # Update containers with annotation-attributes
         self.mne.new_annotation_labels.remove(old_des)
-        self.mne.new_annotation_labels = self.weakmain()._get_annotation_labels()
+        self.mne.new_annotation_labels = \
+            self.weakmain()._get_annotation_labels()
         self.mne.visible_annotations[new_des] = \
             self.mne.visible_annotations.pop(old_des)
         self.mne.annotation_segment_colors[new_des] = \
@@ -2266,7 +2268,8 @@ class AnnotationDock(QDockWidget):
     def _edit_description_selected(self, new_des):
         """Update description only of selected region."""
         old_des = self.mne.selected_region.description
-        idx = self.weakmain()._get_onset_idx(self.mne.selected_region.getRegion()[0])
+        idx = self.weakmain()._get_onset_idx(
+            self.mne.selected_region.getRegion()[0])
         # Update regions & annotations
         self.mne.inst.annotations.description[idx] = new_des
         self.mne.selected_region.update_description(new_des)
@@ -2367,12 +2370,11 @@ class AnnotationDock(QDockWidget):
         bt_layout = QGridLayout()
 
         all_bt = QPushButton('All')
-        from functools import partial
-        #all_bt.clicked.connect(partial(_select_all, chkbxs=chekbxs))
+        all_bt.clicked.connect(partial(_select_all, chkbxs=chekbxs))
         bt_layout.addWidget(all_bt, 0, 0)
 
         clear_bt = QPushButton('Clear')
-        #clear_bt.clicked.connect(partial(_clear_all, chkbxs=chkbxs))
+        clear_bt.clicked.connect(partial(_clear_all, chkbxs=chkbxs))
         bt_layout.addWidget(clear_bt, 0, 1)
 
         ok_bt = QPushButton('Ok')

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -2654,12 +2654,8 @@ def _methpartial(meth, /, **kwargs):
     def call(*args_):
         meth_ = meth()
         if meth_ is not None:
-            try:
-                return meth_(*args_, **kwargs)
-            except Exception:
-                print(*args_)
-                print(kwargs)
-                raise
+            return meth_(*args_, **kwargs)
+
     return call
 
 

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -1970,9 +1970,7 @@ class SelectionDialog(_BaseDialog):
             # MNE >= 1.0
             self.channel_fig.lasso.callbacks.clear()
         for chkbx in self.chkbxs.values():
-            print(chkbx.text())
-            print('*' * 80)
-            _disconnect(chkbx.clicked)
+            _disconnect(chkbx.clicked, allow_error=True)
         if hasattr(self, 'main'):
             self.main.close()
 

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -1970,6 +1970,8 @@ class SelectionDialog(_BaseDialog):
             # MNE >= 1.0
             self.channel_fig.lasso.callbacks.clear()
         for chkbx in self.chkbxs.values():
+            print(chkbx.text())
+            print('*' * 80)
             _disconnect(chkbx.clicked)
         if hasattr(self, 'main'):
             self.main.close()
@@ -2647,7 +2649,7 @@ def _screen_geometry(widget):
         return geometry
 
 
-def _methpartial(meth, /, **kwargs):
+def _methpartial(meth, **kwargs):
     """Use WeakMethod to create a partial method."""
     meth = WeakMethod(meth)
 

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -2370,7 +2370,7 @@ class AnnotationDock(QDockWidget):
         bt_layout = QGridLayout()
 
         all_bt = QPushButton('All')
-        all_bt.clicked.connect(partial(_select_all, chkbxs=chekbxs))
+        all_bt.clicked.connect(partial(_select_all, chkbxs=chkbxs))
         bt_layout.addWidget(all_bt, 0, 0)
 
         clear_bt = QPushButton('Clear')
@@ -2385,6 +2385,8 @@ class AnnotationDock(QDockWidget):
 
         select_dlg.setLayout(layout)
         select_dlg.exec()
+        all_bt.clicked.disconnect()
+        clear_bt.clicked.disconnect()
 
         self.weakmain()._update_regions_visible()
 

--- a/mne_qt_browser/tests/test_pg_specific.py
+++ b/mne_qt_browser/tests/test_pg_specific.py
@@ -207,7 +207,9 @@ def test_pg_toolbar_time_plus_minus(raw_orig, pg_backend):
 
     min_duration = 3 * np.diff(fig.mne.inst.times[:2])[0]  # hard code.
     xmin, xmax = fig.mne.viewbox.viewRange()[0]
-    while xmax - xmin > min_duration:
+    for _ in range(100):
+        if xmax - xmin <= min_duration:
+            break
         fig._fake_click_on_toolbar_action('- Time', wait_after=20)
         xmin, xmax = fig.mne.viewbox.viewRange()[0]
     assert xmax - xmin == min_duration
@@ -219,7 +221,9 @@ def test_pg_toolbar_time_plus_minus(raw_orig, pg_backend):
     assert xmax_new - (xmax + (xmax - xmin * step)) < eps
 
     xmin, xmax = fig.mne.viewbox.viewRange()[0]
-    while xmax + fig.mne.duration * step < fig.mne.xmax:
+    for _ in range(100):
+        if xmax + fig.mne.duration * step >= fig.mne.xmax:
+            break
         fig._fake_click_on_toolbar_action('+ Time', wait_after=20)
         xmin, xmax = fig.mne.viewbox.viewRange()[0]
 
@@ -266,7 +270,9 @@ def test_pg_toolbar_channels_plus_minus(raw_orig, pg_backend):
     if fig.mne.butterfly is True:
         fig._fake_keypress('b')  # toggle butterfly off
 
-    while ymax - ymin > 2:
+    for _ in range(10):
+        if ymax - ymin <= 2:
+            break
         fig._fake_click_on_toolbar_action('- Channels', wait_after=40)
         ymin, ymax = fig.mne.viewbox.viewRange()[1]
     assert ymax - ymin == 2

--- a/mne_qt_browser/tests/test_speed.py
+++ b/mne_qt_browser/tests/test_speed.py
@@ -6,7 +6,6 @@
 
 import sys
 from copy import copy
-from functools import partial
 from time import perf_counter
 
 import numpy as np
@@ -16,15 +15,7 @@ from qtpy.QtWidgets import QApplication
 
 import mne
 from mne_qt_browser.figure import MNEQtBrowser
-
-bm_limit = 50
-bm_count = copy(bm_limit)
-hscroll_dir = True
-vscroll_dir = True
-h_last_time = None
-v_last_time = None
-hscroll_diffs = list()
-vscroll_diffs = list()
+from mne_qt_browser._pg_figure import _methpartial
 
 try:
     import OpenGL  # noqa
@@ -35,86 +26,83 @@ else:
     has_gl = True
     reason = ''
 gl_mark = pytest.mark.skipif(
-        not has_gl, reason=f'Requires PyOpengl (got {reason})')
+    not has_gl, reason=f'Requires PyOpengl (got {reason})')
 
 
-def _reinit_bm_values():
-    global bm_count
-    global hscroll_dir
-    global vscroll_dir
-    global h_last_time
-    global v_last_time
-    global hscroll_diffs
-    global vscroll_diffs
+class _Benchmark:
+    def __init__(self, pg_fig, app, store, request):
+        self.bm_limit = 50
+        self.bm_count = copy(self.bm_limit)
+        self.hscroll_dir = True
+        self.vscroll_dir = True
+        self.h_last_time = None
+        self.v_last_time = None
+        self.hscroll_diffs = list()
+        self.vscroll_diffs = list()
+        assert isinstance(pg_fig, MNEQtBrowser)
+        assert not pg_fig._closed
+        self.pg_fig = pg_fig
+        # # Wait max. 10 s for precomputed data to load
+        if self.pg_fig.load_thread.isRunning():
+            self.pg_fig.load_thread.wait(10000)
+        timer = QTimer(self.pg_fig)
+        timer.timeout.connect(_methpartial(
+            self._initiate_hscroll, store=store, request=request))
+        timer.start(0)
+        self.pg_fig.show()
+        with pytest.raises(SystemExit):
+            sys.exit(app.exec())
 
-    bm_limit = 50
-    bm_count = copy(bm_limit)
-    hscroll_dir = True
-    vscroll_dir = True
-    h_last_time = None
-    v_last_time = None
-    hscroll_diffs = list()
-    vscroll_diffs = list()
+    def _initiate_hscroll(self, *, store, request):
+        if self.bm_count > 0:
+            self.bm_count -= 1
 
-
-def _initiate_hscroll(pg_fig, store, request, timer):
-    global bm_count
-    global hscroll_dir
-    global vscroll_dir
-    global h_last_time
-    global v_last_time
-    assert isinstance(pg_fig, MNEQtBrowser)
-    assert not pg_fig._closed
-    if bm_count > 0:
-        bm_count -= 1
-
-        if pg_fig.mne.is_epochs:
-            t_limit = pg_fig.mne.boundary_times[-1]
-        else:
-            t_limit = pg_fig.mne.inst.times[-1]
-
-        # Scroll in horizontal direction and turn at ends.
-        if pg_fig.mne.t_start + pg_fig.mne.duration >= t_limit:
-            hscroll_dir = False
-        elif pg_fig.mne.t_start <= 0:
-            hscroll_dir = True
-        key = 'right' if hscroll_dir else 'left'
-        pg_fig._fake_keypress(key)
-        # Get time-difference
-        now = perf_counter()
-        if h_last_time is not None:
-            hscroll_diffs.append(now - h_last_time)
-        h_last_time = now
-    elif bm_count > -bm_limit:
-        bm_count -= 1
-        # Scroll in vertical direction and turn at ends.
-        if pg_fig.mne.ch_start + pg_fig.mne.n_channels \
-                >= len(pg_fig.mne.ch_order):
-            vscroll_dir = False
-        elif pg_fig.mne.ch_start <= 0:
-            vscroll_dir = True
-        key = 'down' if vscroll_dir else 'up'
-        pg_fig._fake_keypress(key)
-        # get time-difference
-        now = perf_counter()
-        if v_last_time is not None:
-            vscroll_diffs.append(now - v_last_time)
-        v_last_time = now
-    else:
-        timer.stop()
-
-        h_mean_fps = 1 / np.median(hscroll_diffs)
-        v_mean_fps = 1 / np.median(vscroll_diffs)
-        if pg_fig.mne.is_epochs:
-            if pg_fig.mne.epoch_colors is None:
-                type_key = 'Epochs_unicolor'
+            if self.pg_fig.mne.is_epochs:
+                t_limit = self.pg_fig.mne.boundary_times[-1]
             else:
-                type_key = 'Epochs_multicolor'
+                t_limit = self.pg_fig.mne.inst.times[-1]
+
+            # Scroll in horizontal direction and turn at ends.
+            if self.pg_fig.mne.t_start + self.pg_fig.mne.duration >= t_limit:
+                self.hscroll_dir = False
+            elif self.pg_fig.mne.t_start <= 0:
+                self.hscroll_dir = True
+            key = 'right' if self.hscroll_dir else 'left'
+            self.pg_fig._fake_keypress(key)
+            # Get time-difference
+            now = perf_counter()
+            if self.h_last_time is not None:
+                self.hscroll_diffs.append(now - self.h_last_time)
+            self.h_last_time = now
+        elif self.bm_count > -self.bm_limit:
+            self.bm_count -= 1
+            # Scroll in vertical direction and turn at ends.
+            if self.pg_fig.mne.ch_start + self.pg_fig.mne.n_channels \
+                    >= len(self.pg_fig.mne.ch_order):
+                self.vscroll_dir = False
+            elif self.pg_fig.mne.ch_start <= 0:
+                self.vscroll_dir = True
+            key = 'down' if self.vscroll_dir else 'up'
+            self.pg_fig._fake_keypress(key)
+            # get time-difference
+            now = perf_counter()
+            if self.v_last_time is not None:
+                self.vscroll_diffs.append(now - self.v_last_time)
+            self.v_last_time = now
         else:
-            type_key = 'Raw'
-        store[type_key][request.node.callspec.id] = dict(h=h_mean_fps,
-                                                         v=v_mean_fps)
-        pg_fig.close()
+            h_mean_fps = 1 / np.median(self.hscroll_diffs)
+            v_mean_fps = 1 / np.median(self.vscroll_diffs)
+            if self.pg_fig.mne.is_epochs:
+                if self.pg_fig.mne.epoch_colors is None:
+                    type_key = 'Epochs_unicolor'
+                else:
+                    type_key = 'Epochs_multicolor'
+            else:
+                type_key = 'Raw'
+            store[type_key][request.node.callspec.id] = dict(
+                h=h_mean_fps, v=v_mean_fps)
+            self.pg_fig.close()
+            del self.pg_fig
 
 
 @pytest.mark.benchmark
@@ -133,27 +121,12 @@ def test_scroll_speed_raw(raw_orig, benchmark_param, store,
                           pg_backend, request):
     """Test the speed of a parameter."""
     # Remove spaces and get params with values
-
-    _reinit_bm_values()
-
     app = QApplication.instance()
     if app is None:
         app = QApplication(sys.argv)
     fig = raw_orig.plot(duration=5, n_channels=40,
                         show=False, block=False, **benchmark_param)
-
-    # # Wait max. 10 s for precomputed data to load
-    if fig.load_thread.isRunning():
-        fig.load_thread.wait(10000)
-
-    timer = QTimer()
-    timer.timeout.connect(partial(_initiate_hscroll, fig, store,
-                                  request, timer))
-    timer.start(0)
-
-    fig.show()
-    with pytest.raises(SystemExit):
-        sys.exit(app.exec())
+    _Benchmark(fig, app, store, request)
 
 
 def _check_epochs_version():
@@ -177,10 +150,7 @@ def _check_epochs_version():
 ])
 def test_scroll_speed_epochs_unicolor(raw_orig, benchmark_param, store,
                                       pg_backend, request):
-    from qtpy.QtCore import QTimer
-    from qtpy.QtWidgets import QApplication
     _check_epochs_version()
-    _reinit_bm_values()
 
     app = QApplication.instance()
     if app is None:
@@ -194,19 +164,7 @@ def test_scroll_speed_epochs_unicolor(raw_orig, benchmark_param, store,
     epochs.info._unlocked = True
 
     fig = epochs.plot(show=False, block=False, **benchmark_param)
-
-    # # Wait max. 10 s for precomputed data to load
-    if fig.load_thread.isRunning():
-        fig.load_thread.wait(10000)
-
-    timer = QTimer()
-    timer.timeout.connect(partial(_initiate_hscroll, fig, store,
-                                  request, timer))
-    timer.start(0)
-
-    fig.show()
-    with pytest.raises(SystemExit):
-        sys.exit(app.exec())
+    _Benchmark(fig, app, store, request)
 
 
 @pytest.mark.benchmark
@@ -223,10 +181,8 @@ def test_scroll_speed_epochs_unicolor(raw_orig, benchmark_param, store,
 ])
 def test_scroll_speed_epochs_multicolor(raw_orig, benchmark_param, store,
                                         pg_backend, request):
-    from qtpy.QtCore import QTimer
     from qtpy.QtWidgets import QApplication
     _check_epochs_version()
-    _reinit_bm_values()
 
     app = QApplication.instance()
     if app is None:
@@ -259,16 +215,4 @@ def test_scroll_speed_epochs_multicolor(raw_orig, benchmark_param, store,
 
     fig = epochs.plot(show=False, block=False, epoch_colors=epoch_colors,
                       **benchmark_param)
-
-    # # Wait max. 10 s for precomputed data to load
-    if fig.load_thread.isRunning():
-        fig.load_thread.wait(10000)
-
-    timer = QTimer()
-    timer.timeout.connect(partial(_initiate_hscroll, fig, store,
-                                  request, timer))
-    timer.start(0)
-
-    fig.show()
-    with pytest.raises(SystemExit):
-        sys.exit(app.exec())
+    _Benchmark(fig, app, store, request)

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -7,3 +7,4 @@ tqdm
 sklearn  # for testing ICA
 pytest-harvest
 pytest-error-for-skips
+https://github.com/sphinx-gallery/sphinx-gallery.git  # for testing scrapers

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -7,4 +7,4 @@ tqdm
 sklearn  # for testing ICA
 pytest-harvest
 pytest-error-for-skips
-https://github.com/sphinx-gallery/sphinx-gallery.git  # for testing scrapers
+https://github.com/sphinx-gallery/sphinx-gallery/zipball/master  # for testing scrapers


### PR DESCRIPTION
In https://github.com/mne-tools/mne-python/pull/11205 you can see reference problems pop up on CircleCI, GH Actions, and Azure when we assert that garbage can be collected properly on plotter close. This is because PyQt5/PyQt6 appear to have issues when `signal.connect` is called using a `partial` of a bound method -- `gc` can't seem to resolve these on its own. I think we can fix them using `weakref.WeakMethod`, which I've done here.

Also becomes more selective about error resolution by only allowing disconnect errors when it's a separator (i.e., `action.text() == ''`, since `addSeparator` actually creates a `QAction` in the toolbar).

To verify this is the correct fix, though, we should try using this branch in https://github.com/mne-tools/mne-python/pull/11205 and make sure CIs come back green.