### PR TITLE
Change req. from sklearn to scikit-learn

### DIFF
--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -4,7 +4,7 @@ pytest-cov
 pytest-timeout
 pooch
 tqdm
-sklearn  # for testing ICA
+scikit-learn  # for testing ICA
 pytest-harvest
 pytest-error-for-skips
 https://github.com/sphinx-gallery/sphinx-gallery/zipball/master  # for testing scrapers


### PR DESCRIPTION
Unless I am mistaken, `pip install sklearn` does not work anymore; in favor of `pip install scikit-learn`. 