### PR TITLE
Fix scrolling through data with a visualization filter

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -3444,6 +3444,9 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
             xmax = self.mne.xmax
             xmin = xmax - self.mne.duration
 
+        if self.mne.filter_coefs is not None:
+            self._rerun_precompute()
+
         self.mne.plt.setXRange(xmin, xmax, padding=0)
 
     def vscroll(self, step):
@@ -3503,6 +3506,9 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
 
         if xmin < 0:
             xmin = 0
+
+        if self.mne.filter_coefs is not None:
+            self._rerun_precompute()
 
         self.mne.ax_hscroll.update_duration()
         self.mne.plt.setXRange(xmin, xmax, padding=0)

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -2606,7 +2606,7 @@ class LoadThread(QThread):
         # Deactive remove dc because it will be removed for visible range
         stashed_remove_dc = self.mne.remove_dc
         self.mne.remove_dc = False
-        data = browser._process_data(data, 0, len(data), picks, self)
+        data = browser._process_data(data, 0, data.shape[-1], picks, self)
         self.mne.remove_dc = stashed_remove_dc
 
         self.mne.global_data = data

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -4174,10 +4174,11 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
             self.mne.fig_proj.toggle_all()
 
     def _toggle_whitening(self):
-        super()._toggle_whitening()
-        # If data was precomputed it needs to be precomputed again.
-        self._rerun_precompute()
-        self._redraw()
+        if self.mne.noise_cov is not None:
+            super()._toggle_whitening()
+            # If data was precomputed it needs to be precomputed again.
+            self._rerun_precompute()
+            self._redraw()
 
     def _toggle_settings_fig(self):
         if self.mne.fig_settings is None:

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -3444,9 +3444,6 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
             xmax = self.mne.xmax
             xmin = xmax - self.mne.duration
 
-        if self.mne.filter_coefs is not None:
-            self._rerun_precompute()
-
         self.mne.plt.setXRange(xmin, xmax, padding=0)
 
     def vscroll(self, step):
@@ -3506,9 +3503,6 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
 
         if xmin < 0:
             xmin = 0
-
-        if self.mne.filter_coefs is not None:
-            self._rerun_precompute()
 
         self.mne.ax_hscroll.update_duration()
         self.mne.plt.setXRange(xmin, xmax, padding=0)


### PR DESCRIPTION
Fixes #167, `mne.global_data` was not correctly pre-computed because of an indexing error. 

~~It looks to me like `main._rerun_precompute()` must be run before updating the xRange, to run through https://github.com/mne-tools/mne-python/blob/d158117a716512fbe96d8ff6c4d735f1e9601d09/mne/viz/_figure.py#L349-L385 and to apply the visualization filters.~~

--------------

~~For the click on the overview bar, I'm lacking a good idea to fix it. The update happens in the OverviewBar class, here: https://github.com/mne-tools/mne-qt-browser/blob/f07ab8a2509b6d76c1fca9d2a2326c545a25eb1c/mne_qt_browser/_pg_figure.py#L1050~~
~~and it doesn't have a reference to `main`, to `_rerun_precompute` or to `load_thread`..~~

--------------

~~There is also this update in the `TimeScrollBar` class: https://github.com/mne-tools/mne-qt-browser/blob/f07ab8a2509b6d76c1fca9d2a2326c545a25eb1c/mne_qt_browser/_pg_figure.py#L693-L701
~~and I have no idea when it is triggered with `self.external_change` set to False.~~

--------------

And as a side-change, I added `self.mne.noise_cov is not None` to disable `w`-key if there is nothing to do.