### PR TITLE
Lower zvalue from bad traces to 0

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -417,6 +417,10 @@ class DataTrace(PlotCurveItem):
 
             # Update line color status
             self.isbad = not self.isbad
+            if self.isbad:
+                self.setZValue(0)
+            else:
+                self.setZValue(1)
 
             # Update colors for epochs
             if self.mne.is_epochs:


### PR DESCRIPTION
Default z value for a trace is 1. This PR lowers it to 0 for bad traces which are not as important.
Partially fix #170 