### PR TITLE
Use weakmain in the annotation dialog box

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -2099,7 +2099,7 @@ class AnnotRegion(LinearRegionItem):
 
 class _AnnotEditDialog(_BaseDialog):
     def __init__(self, annot_dock):
-        super().__init__(annot_dock.main, title='Edit Annotations')
+        super().__init__(annot_dock.weakmain, title='Edit Annotations')
         self.ad = annot_dock
 
         self.current_mode = None


### PR DESCRIPTION
A very unreliable bug reported today at our site, I managed to observe it twice on 2 different computers, among which mine but I am unable to reliably reproduce it. After playing with annotations, upon closing the browser, the following error is raised:

```
File "[...]/mne_qt_browser/_pg_figure.py", line 2305, in _edit_description_dlg
    _AnnotEditDialog(self)
File "[...]/mne_qt_browser/_pg_figure.py", line 2102 in __init__
    super().__init__(annot_dock.main, title=[...])
AttributeError: 'AnnotationDock' object has no attribute 'main'
```

Yes, I had to write the traceback from a screenshot :sob: 
My guess is that `annot_dock.main` is garbage collected early. Changing to a weakref does not seem to break anything, and that might fix this issue?