### PR TITLE
Remove shortcut "h" plotting epoch PTP amp when viewing raw

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -4332,10 +4332,6 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
         self.mne.remove_dc = not self.mne.remove_dc
         self._redraw()
 
-    def _toggle_epoch_histogram(self):
-        fig = self._create_epoch_histogram()
-        self._get_dlg_from_mpl(fig)
-
     def _set_events_visible(self, visible):
         for event_line in self.mne.event_lines:
             event_line.setVisible(visible)
@@ -4421,7 +4417,7 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
         if fig is not None:
             self._get_dlg_from_mpl(fig)
 
-    def _toggle_epoch_histogramm(self):
+    def _toggle_epoch_histogram(self):
         if self.mne.is_epochs:
             fig = self._create_epoch_histogram()
             if fig is not None:

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -3393,6 +3393,9 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
         if self.mne.is_epochs:
             # Disable time format toggling
             del self.mne.keyboard_shortcuts['t']
+        else:
+            # dissable histogram of epoch PTP amplitude
+            del self.mne.keyboard_shortcuts["h"]
 
     def _hidpi_mkPen(self, *args, **kwargs):
         kwargs['width'] = self._pixel_ratio * kwargs.get('width', 1.)

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -3394,7 +3394,7 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
             # Disable time format toggling
             del self.mne.keyboard_shortcuts['t']
         else:
-            # dissable histogram of epoch PTP amplitude
+            # disable histogram of epoch PTP amplitude
             del self.mne.keyboard_shortcuts["h"]
 
     def _hidpi_mkPen(self, *args, **kwargs):


### PR DESCRIPTION
So, pressing "h" on a `Raw` would not do anything, until you close the browser and open it again. Nice traceback ;)

The key `h` calls `_toggle_epoch_histogram`, which is not checking if we are plotting raw or epochs; while the function `_toggle_epoch_histogramm` with 2 `m` at the end does the same stuff correctly and is unused. 
This PR fixes that typo and removes the shortcut `h` entirely for raw recordings.