### PR TITLE
Disable time format if we don't have a measurement date

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -3394,6 +3394,8 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
             # Disable time format toggling
             del self.mne.keyboard_shortcuts['t']
         else:
+            if self.mne.info["meas_date"] is None:
+                del self.mne.keyboard_shortcuts["t"]
             # disable histogram of epoch PTP amplitude
             del self.mne.keyboard_shortcuts["h"]
 
@@ -4344,13 +4346,14 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
             self._set_events_visible(self.mne.events_visible)
 
     def _toggle_time_format(self):
-        if self.mne.time_format == 'float':
-            self.mne.time_format = 'clock'
-            self.mne.time_axis.setLabel(text='Time of day')
-        else:
-            self.mne.time_format = 'float'
-            self.mne.time_axis.setLabel(text='Time', units='s')
-        self._update_yaxis_labels()
+        if self.mne.info["meas_date"] is not None:
+            if self.mne.time_format == 'float':
+                self.mne.time_format = 'clock'
+                self.mne.time_axis.setLabel(text='Time of day')
+            else:
+                self.mne.time_format = 'float'
+                self.mne.time_axis.setLabel(text='Time', units='s')
+            self._update_yaxis_labels()
 
     def _toggle_fullscreen(self):
         if self.isFullScreen():


### PR DESCRIPTION
Don't allow "T" shortcut if we don't have a measurement date.

Traceback:

```
TypeError                                 Traceback (most recent call last)
File ~\pyvenv\mscheltienne\eeg-flow\lib\site-packages\pyqtgraph\graphicsItems\AxisItem.py:654, in AxisItem.paint(self, p, opt, widget)
    652 if self.style["tickFont"]:
    653     painter.setFont(self.style["tickFont"])
--> 654 specs = self.generateDrawSpecs(painter)
    655 profiler('generate specs')
    656 if specs is not None:

File ~\pyvenv\mscheltienne\eeg-flow\lib\site-packages\pyqtgraph\graphicsItems\AxisItem.py:1100, in AxisItem.generateDrawSpecs(self, p)
   1098 if tickStrings is None:
   1099     spacing, values = tickLevels[i]
-> 1100     strings = self.tickStrings(values, self.autoSIPrefixScale * self.scale, spacing)
   1101 else:
   1102     strings = tickStrings[i]

File ~\git\mne-tools\mne-qt-browser\mne_qt_browser\_pg_figure.py:509, in TimeAxis.tickStrings(self, values, scale, spacing)
    507 tick_strings = list()
    508 for val in values:
--> 509     val_time = datetime.timedelta(seconds=val) + \
    510                first_time + meas_date
    511     val_str = val_time.strftime('%H:%M:%S')
    512     if int(val_time.microsecond):

TypeError: unsupported operand type(s) for +: 'datetime.timedelta' and 'NoneType'
```