### PR TITLE
Fix removal of DC on precomputed data when nan's are present in the array

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -4008,9 +4008,9 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
 
             # remove DC locally
             if self.mne.remove_dc:
-                self.mne.data = self.mne.data - \
-                                self.mne.data.mean(axis=1, keepdims=True)
-
+                self.mne.data = (
+                    self.mne.data - np.nanmean(self.mne.data, axis=1, keepdims=True)
+                )
         else:
             # While data is not precomputed get data only from shown range and
             # process only those.


### PR DESCRIPTION
Reported [here](https://mne.discourse.group/t/eyetracking-and-qt-browser-traces-of-x-y-position-disappear/7254/3) by @sappelhoff 

cc @scott-huberty