### PR TITLE
MAINT: Use pre-commit and updates for NumPy

### DIFF
--- a/.github/workflows/qt_viz_tests.yml
+++ b/.github/workflows/qt_viz_tests.yml
@@ -10,20 +10,6 @@ on:
       - cron: "0 4 * * 1"  # At 04:00 on Monday
 
 jobs:
-  style:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install ruff
-      - name: Lint with ruff
-        run: ruff .
   pytest:
     strategy:
       fail-fast: false
@@ -33,6 +19,7 @@ jobs:
         opengl: ['opengl']
         python: ['3.11']
         name: [matrix]
+        pip: ['']
         include:
           - os: ubuntu
             mne: main
@@ -54,6 +41,12 @@ jobs:
             opengl: 'opengl'
             python: '3.9'
             name: old
+          - os: ubuntu
+            mne: main
+            opengl: 'opengl'
+            python: '3.11'
+            pip: pre
+            name: pip-pre
     name: pytest ${{ matrix.name }} / ${{ matrix.os }} / MNE ${{ matrix.mne }}
     runs-on: ${{ matrix.os }}-latest
     env:
@@ -85,6 +78,10 @@ jobs:
             PIP_OPTION="[tests]"
           fi
           python -m pip install -ve .${PIP_OPTION} PyQt5
+          if [[ "${{ matrix.pip }}" == "pre" ]]; then
+            echo "Upgrading to pre-release NumPy, SciPy, and matplotlib"
+            python -m pip install --upgrade --pre --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" numpy scipy matplotlib
+          fi
       - run: ./tools/get_testing_version.sh
         name: 'Get testing version'
         working-directory: ../mne-python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 repos:
-- repo: https://github.com/psf/black
-  rev: 23.3.0
-  hooks:
-    - id: black
-      args: [--quiet]
+#- repo: https://github.com/psf/black
+#  rev: 23.3.0
+#  hooks:
+#    - id: black
+#      args: [--quiet]
 - repo: https://github.com/charliermarsh/ruff-pre-commit
   rev: v0.0.262
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+- repo: https://github.com/psf/black
+  rev: 23.3.0
+  hooks:
+    - id: black
+      args: [--quiet]
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  rev: v0.0.262
+  hooks:
+    - id: ruff

--- a/mne_qt_browser/conftest.py
+++ b/mne_qt_browser/conftest.py
@@ -4,24 +4,23 @@
 #
 # License: BSD-3-Clause
 
-
+import os
 import pytest
 
-from mne.conftest import (raw_orig, pg_backend, garbage_collect)  # noqa: F401
+from mne.conftest import raw_orig, pg_backend, garbage_collect  # noqa: F401
 
-_store = {'Raw': {},
-          'Epochs_unicolor': {},
-          'Epochs_multicolor': {}}
+_store = {"Raw": {}, "Epochs_unicolor": {}, "Epochs_multicolor": {}}
 
 
 def pytest_configure(config):
     """Configure pytest options."""
     # Markers
-    for marker in ('benchmark', 'pgtest', 'slowtest'):
-        config.addinivalue_line('markers', marker)
+    for marker in ("benchmark", "pgtest", "slowtest"):
+        config.addinivalue_line("markers", marker)
+    os.environ["_MNE_BROWSER_BACK"] = "true"
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def store():
     """Yield our storage object."""
     yield _store
@@ -32,12 +31,13 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     if not any(len(_store[key]) for key in _store):
         return
     writer = terminalreporter
-    writer.line('')  # newline
-    writer.write_sep('=', 'benchmark results')
+    writer.line("")  # newline
+    writer.write_sep("=", "benchmark results")
     for type_name, results in _store.items():
-        writer.write_sep('-', type_name)
+        writer.write_sep("-", type_name)
         for name, vals in results.items():
             writer.line(
-                f'{name}:\n'
+                f"{name}:\n"
                 f'    Horizontal: {vals["h"]:6.2f}\n'
-                f'    Vertical:   {vals["v"]:6.2f}')
+                f'    Vertical:   {vals["v"]:6.2f}'
+            )

--- a/mne_qt_browser/conftest.py
+++ b/mne_qt_browser/conftest.py
@@ -17,7 +17,8 @@ def pytest_configure(config):
     # Markers
     for marker in ("benchmark", "pgtest", "slowtest"):
         config.addinivalue_line("markers", marker)
-    os.environ["_MNE_BROWSER_BACK"] = "true"
+    if "_MNE_BROWSER_BACK" not in os.environ:
+        os.environ["_MNE_BROWSER_BACK"] = "true"
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
1. Push windows to the back by default (helps when running `pytest` from the terminal not to see a million windows pop up)
2. Use `pre-commit.ci` to take care of style
3. Test prerelease NumPy and matplotlib (see also https://github.com/mne-tools/mne-python/pull/11837)