### PR TITLE
Fix: remove description bug

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -2375,27 +2375,28 @@ class AnnotationDock(QDockWidget):
                 icon=QMessageBox.Information)
 
     def _remove_description(self, rm_description):
-        # Remove regions
-        for rm_region in [r for r in self.mne.regions
-                          if r.description == rm_description]:
-            rm_region.remove()
+        if rm_description != "":
+            # Remove regions
+            for rm_region in [r for r in self.mne.regions
+                              if r.description == rm_description]:
+                rm_region.remove()
 
-        # Remove from descriptions
-        self.mne.new_annotation_labels.remove(rm_description)
-        self._update_description_cmbx()
+            # Remove from descriptions
+            self.mne.new_annotation_labels.remove(rm_description)
+            self._update_description_cmbx()
 
-        # Remove from visible annotations
-        self.mne.visible_annotations.pop(rm_description)
+            # Remove from visible annotations
+            self.mne.visible_annotations.pop(rm_description)
 
-        # Remove from color-mapping
-        if rm_description in self.mne.annotation_segment_colors:
-            self.mne.annotation_segment_colors.pop(rm_description)
+            # Remove from color-mapping
+            if rm_description in self.mne.annotation_segment_colors:
+                self.mne.annotation_segment_colors.pop(rm_description)
 
-        # Set first description in Combo-Box to current description
-        if self.description_cmbx.count() > 0:
-            self.description_cmbx.setCurrentIndex(0)
-            self.mne.current_description = \
-                self.description_cmbx.currentText()
+            # Set first description in Combo-Box to current description
+            if self.description_cmbx.count() > 0:
+                self.description_cmbx.setCurrentIndex(0)
+                self.mne.current_description = \
+                    self.description_cmbx.currentText()
 
     def _remove_description_dlg(self):
         rm_description = self.description_cmbx.currentText()

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -1309,6 +1309,7 @@ class RawViewBox(ViewBox):
                 self.weakmain().message_box(
                     text='No description!',
                     info_text='No description is given, add one!',
+                    buttons=QMessageBox.Ok,
                     icon=QMessageBox.Warning)
 
     def mouseClickEvent(self, event):

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -1258,52 +1258,53 @@ class RawViewBox(ViewBox):
                                                     description=description,
                                                     values=(self._drag_start,
                                                             drag_stop))
-                elif event.isFinish():
-                    drag_stop = self.mapSceneToView(event.scenePos()).x()
-                    drag_stop = 0 if drag_stop < 0 else drag_stop
-                    drag_stop = (
-                        self.mne.xmax if self.mne.xmax < drag_stop else drag_stop
-                    )
-                    self._drag_region.setRegion((self._drag_start, drag_stop))
-                    plot_onset = min(self._drag_start, drag_stop)
-                    plot_offset = max(self._drag_start, drag_stop)
-                    duration = abs(self._drag_start - drag_stop)
+                elif self._drag_region is not None:
+                    if event.isFinish():
+                        drag_stop = self.mapSceneToView(event.scenePos()).x()
+                        drag_stop = 0 if drag_stop < 0 else drag_stop
+                        drag_stop = (
+                            self.mne.xmax if self.mne.xmax < drag_stop else drag_stop
+                        )
+                        self._drag_region.setRegion((self._drag_start, drag_stop))
+                        plot_onset = min(self._drag_start, drag_stop)
+                        plot_offset = max(self._drag_start, drag_stop)
+                        duration = abs(self._drag_start - drag_stop)
 
-                    # Add to annotations
-                    onset = _sync_onset(self.mne.inst, plot_onset,
-                                        inverse=True)
-                    _merge_annotations(onset, onset + duration,
-                                       self.mne.current_description,
-                                       self.mne.inst.annotations)
+                        # Add to annotations
+                        onset = _sync_onset(self.mne.inst, plot_onset,
+                                            inverse=True)
+                        _merge_annotations(onset, onset + duration,
+                                           self.mne.current_description,
+                                           self.mne.inst.annotations)
 
-                    # Add to regions/merge regions
-                    merge_values = [plot_onset, plot_offset]
-                    rm_regions = list()
-                    for region in [r for r in self.mne.regions
-                                   if r.description ==
-                                   self.mne.current_description]:
-                        values = region.getRegion()
-                        if any([plot_onset < val < plot_offset for val in
-                                values]):
-                            merge_values += values
-                            rm_regions.append(region)
-                    if len(merge_values) > 2:
-                        self._drag_region.setRegion((min(merge_values),
-                                                     max(merge_values)))
-                    for rm_region in rm_regions:
-                        self.weakmain()._remove_region(
-                            rm_region, from_annot=False)
-                    self.weakmain()._add_region(
-                        plot_onset, duration, self.mne.current_description,
-                        region=self._drag_region)
-                    self._drag_region.select(True)
-                    self._drag_region.setZValue(2)
+                        # Add to regions/merge regions
+                        merge_values = [plot_onset, plot_offset]
+                        rm_regions = list()
+                        for region in [r for r in self.mne.regions
+                                       if r.description ==
+                                       self.mne.current_description]:
+                            values = region.getRegion()
+                            if any([plot_onset < val < plot_offset for val in
+                                    values]):
+                                merge_values += values
+                                rm_regions.append(region)
+                        if len(merge_values) > 2:
+                            self._drag_region.setRegion((min(merge_values),
+                                                         max(merge_values)))
+                        for rm_region in rm_regions:
+                            self.weakmain()._remove_region(
+                                rm_region, from_annot=False)
+                        self.weakmain()._add_region(
+                            plot_onset, duration, self.mne.current_description,
+                            region=self._drag_region)
+                        self._drag_region.select(True)
+                        self._drag_region.setZValue(2)
 
-                    # Update Overview-Bar
-                    self.mne.overview_bar.update_annotations()
-                else:
-                    x_to = self.mapSceneToView(event.scenePos()).x()
-                    self._drag_region.setRegion((self._drag_start, x_to))
+                        # Update Overview-Bar
+                        self.mne.overview_bar.update_annotations()
+                    else:
+                        x_to = self.mapSceneToView(event.scenePos()).x()
+                        self._drag_region.setRegion((self._drag_start, x_to))
 
             elif event.isFinish():
                 self.weakmain().message_box(

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -1258,53 +1258,52 @@ class RawViewBox(ViewBox):
                                                     description=description,
                                                     values=(self._drag_start,
                                                             drag_stop))
-                elif self._drag_region is not None:
-                    if event.isFinish():
-                        drag_stop = self.mapSceneToView(event.scenePos()).x()
-                        drag_stop = 0 if drag_stop < 0 else drag_stop
-                        drag_stop = (
-                            self.mne.xmax if self.mne.xmax < drag_stop else drag_stop
-                        )
-                        self._drag_region.setRegion((self._drag_start, drag_stop))
-                        plot_onset = min(self._drag_start, drag_stop)
-                        plot_offset = max(self._drag_start, drag_stop)
-                        duration = abs(self._drag_start - drag_stop)
+                elif event.isFinish():
+                    drag_stop = self.mapSceneToView(event.scenePos()).x()
+                    drag_stop = 0 if drag_stop < 0 else drag_stop
+                    drag_stop = (
+                        self.mne.xmax if self.mne.xmax < drag_stop else drag_stop
+                    )
+                    self._drag_region.setRegion((self._drag_start, drag_stop))
+                    plot_onset = min(self._drag_start, drag_stop)
+                    plot_offset = max(self._drag_start, drag_stop)
+                    duration = abs(self._drag_start - drag_stop)
 
-                        # Add to annotations
-                        onset = _sync_onset(self.mne.inst, plot_onset,
-                                            inverse=True)
-                        _merge_annotations(onset, onset + duration,
-                                           self.mne.current_description,
-                                           self.mne.inst.annotations)
+                    # Add to annotations
+                    onset = _sync_onset(self.mne.inst, plot_onset,
+                                        inverse=True)
+                    _merge_annotations(onset, onset + duration,
+                                       self.mne.current_description,
+                                       self.mne.inst.annotations)
 
-                        # Add to regions/merge regions
-                        merge_values = [plot_onset, plot_offset]
-                        rm_regions = list()
-                        for region in [r for r in self.mne.regions
-                                       if r.description ==
-                                       self.mne.current_description]:
-                            values = region.getRegion()
-                            if any([plot_onset < val < plot_offset for val in
-                                    values]):
-                                merge_values += values
-                                rm_regions.append(region)
-                        if len(merge_values) > 2:
-                            self._drag_region.setRegion((min(merge_values),
-                                                         max(merge_values)))
-                        for rm_region in rm_regions:
-                            self.weakmain()._remove_region(
-                                rm_region, from_annot=False)
-                        self.weakmain()._add_region(
-                            plot_onset, duration, self.mne.current_description,
-                            region=self._drag_region)
-                        self._drag_region.select(True)
-                        self._drag_region.setZValue(2)
+                    # Add to regions/merge regions
+                    merge_values = [plot_onset, plot_offset]
+                    rm_regions = list()
+                    for region in [r for r in self.mne.regions
+                                   if r.description ==
+                                   self.mne.current_description]:
+                        values = region.getRegion()
+                        if any([plot_onset < val < plot_offset for val in
+                                values]):
+                            merge_values += values
+                            rm_regions.append(region)
+                    if len(merge_values) > 2:
+                        self._drag_region.setRegion((min(merge_values),
+                                                     max(merge_values)))
+                    for rm_region in rm_regions:
+                        self.weakmain()._remove_region(
+                            rm_region, from_annot=False)
+                    self.weakmain()._add_region(
+                        plot_onset, duration, self.mne.current_description,
+                        region=self._drag_region)
+                    self._drag_region.select(True)
+                    self._drag_region.setZValue(2)
 
-                        # Update Overview-Bar
-                        self.mne.overview_bar.update_annotations()
-                    else:
-                        x_to = self.mapSceneToView(event.scenePos()).x()
-                        self._drag_region.setRegion((self._drag_start, x_to))
+                    # Update Overview-Bar
+                    self.mne.overview_bar.update_annotations()
+                else:
+                    x_to = self.mapSceneToView(event.scenePos()).x()
+                    self._drag_region.setRegion((self._drag_start, x_to))
 
             elif event.isFinish():
                 self.weakmain().message_box(


### PR DESCRIPTION
## What does this fix?
This fixes an error when hitting "Remove description" when all are already removed

## How to reproduce the error:
```python
import mne
import os
import numpy as np

from mne.viz import use_browser_backend

# Load Raw
sample_data_folder = mne.datasets.sample.data_path()
raw_file = os.path.join(sample_data_folder, 'MEG', 'sample',
                        'sample_audvis_raw.fif')
raw = mne.io.read_raw(raw_file)

# Add test-annotations
annotations = mne.Annotations([1, 10, 20, 30],
                              [1, 2, 1, 2],
                              ['a', 'b', 'a', 'b'])
raw.set_annotations(annotations)

with use_browser_backend('qt'):
    browser = raw.plot(events=events, block=True, title='Sample-Data',
                       clipping=None, show=True, precompute=True,
                       use_opengl=True, theme='auto')
```
Then remove all descriptions from the plot in annotation mode and hit "Remove description" again.