### PR TITLE
Apply the update to the projectors on bad channel toggle

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -2053,9 +2053,7 @@ class AnnotRegion(LinearRegionItem):
         # remove merged regions
         overlapping_regions = list()
         for region in self.mne.regions:
-            if region.description != self.description:
-                continue
-            if id(self) == id(region):
+            if region.description != self.description or id(self) == id(region):
                 continue
             values = region.getRegion()
             if any(self.getRegion()[0] <= val <= self.getRegion()[1] for val in values):

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -37,7 +37,7 @@ from qtpy.QtWidgets import (QAction, QColorDialog, QComboBox, QDialog,
                             QGraphicsLineItem, QGraphicsScene, QTextEdit,
                             QSizePolicy, QSpinBox, QSlider, QWidgetAction,
                             QRadioButton)
-from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg
 from matplotlib.colors import to_rgba_array
 from pyqtgraph import (AxisItem, GraphicsView, InfLineLabel, InfiniteLine,
                        LinearRegionItem, PlotCurveItem, PlotItem,

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -419,6 +419,7 @@ class DataTrace(PlotCurveItem):
         else:
             bad_color, pick, marked_bad = self.weakmain()._toggle_bad_channel(
                 self.range_idx)
+            self.weakmain()._apply_update_projectors()
 
             # Update line color status
             self.isbad = not self.isbad


### PR DESCRIPTION
Closes #186

The projectors were updated, but the update was not applied. Likely the pre-computation has to be re-run.
Anyway, that small change fixes the issue. It does however mean that we run twice through `self._update_projector()` because `_toggle_bad_channel` defined in `mne-python` runs it as well, but the cost is small.

Also, I noticed an import of the Qt5 backend at the top of the file. I'm guessing that whatever functionality uses it is currently failing with a Qt6 binding, but I did not test this. We had a similar import in `mne-icalabel` that failed when we started using 22.04 LTS + `qt6-base-dev` instead of 20.04 LTS + `qt5-default` (https://github.com/mne-tools/mne-icalabel/pull/120).