### PR TITLE
MAINT: Safer check

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -608,7 +608,10 @@ class ChannelAxis(AxisItem):
                              if k in [tr.ch_name for tr in self.mne.traces]}
             # Get channel-name from position of channel-description
             ypos = event.scenePos().y()
-            y_values = np.asarray(list(self.ch_texts.values()))[:, 1, :]
+            y_values = list(self.ch_texts.values())
+            if len(y_values) == 0:
+                return
+            y_values = np.array(y_values, float)[:, 1, :]
             y_diff = np.abs(y_values - ypos)
             ch_idx = int(np.argmin(y_diff, axis=0)[0])
             ch_name = list(self.ch_texts)[ch_idx]


### PR DESCRIPTION
Every once in a while in testing I get:
```
________________________________________________________________________ test_plot_instance_components[qt] _________________________________________________________________________
mne/viz/tests/test_ica.py:521: in test_plot_instance_components
    fig._fake_click((x, y), xform="data")
../mne-qt-browser/mne_qt_browser/_pg_figure.py:4665: in _fake_click
    raise RuntimeError(f'There as been an {exc[0]} inside the Qt '
E   RuntimeError: There as been an <class 'RuntimeWarning'> inside the Qt event loop (look above for traceback).
...
Traceback (most recent call last):
  File "/home/larsoner/python/virtualenvs/base/lib/python3.11/site-packages/pyqtgraph/GraphicsScene/GraphicsScene.py", line 378, in sendClickEvent
    item.mouseClickEvent(ev)
  File "/home/larsoner/python/mne-qt-browser/mne_qt_browser/_pg_figure.py", line 612, in mouseClickEvent
    y_values = np.asarray(list(self.ch_texts.values()))[:, 1, :]
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
IndexError: too many indices for array: array is 1-dimensional, but 3 were indexed
```
Not quite sure why this happens, but this PR works around the issue by short-circuiting if there are no values.