### PR TITLE
Update pyproject.toml adding pyqt5 binding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "pyopengl; platform_system=='Darwin'",
     "darkdetect",
     "qdarkstyle",
+    "pyqt5"
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
When installing mne-qt-browser under Windows 11, mne version 1.5.1, `pip install mne-qt-browser` does not install the required qt binding.

`raw.plot()` therefore results in the error:

> No Qt bindings could be found
> Traceback (most recent call last):
>   File "<string>", line 1, in <module>
>   File "C:\Users\ICN_admin\Anaconda3\envs\bispectra\lib\site-packages\mne\io\base.py", line 1825, in plot
>     return plot_raw(
>   File "<decorator-gen-202>", line 12, in plot_raw
>   File "C:\Users\ICN_admin\Anaconda3\envs\bispectra\lib\site-packages\mne\viz\raw.py", line 400, in plot_raw
>     fig = _get_browser(show=show, block=block, **params)
>   File "C:\Users\ICN_admin\Anaconda3\envs\bispectra\lib\site-packages\mne\viz\_figure.py", line 698, in _get_browser
>     fig = backend._init_browser(**kwargs)
> AttributeError: 'NoneType' object has no attribute '_init_browser'

Installing pyqt5 with `pip installl pyqt5` fixes the issue as described [here](https://github.com/spyder-ide/spyder/issues/3545#issuecomment-254049249). Therefore I added the dependency to the `pyproject.toml`