### PR TITLE
Improve error message if qt binding could not be found

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -23,18 +23,7 @@ from os.path import getsize
 import numpy as np
 
 try:
-    from qtpy.QtCore import (
-        QEvent,
-        QThread,
-        Qt,
-        Signal,
-        QRectF,
-        QLineF,
-        QPointF,
-        QPoint,
-        QSettings,
-        QSignalBlocker,
-    )
+    from qtpy.QtCore import Qt
 except Exception as exc:
     if exc.__class__.__name__ == "QtBindingsNotFoundError":
         raise ImportError(
@@ -43,6 +32,18 @@ except Exception as exc:
     else:
         raise
 
+ from qtpy.QtCore import (
+    QEvent,
+    QThread,
+    Qt,
+    Signal,
+    QRectF,
+    QLineF,
+    QPointF,
+    QPoint,
+    QSettings,
+    QSignalBlocker,
+)
 from qtpy.QtGui import (
     QFont,
     QIcon,

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -37,7 +37,9 @@ try:
     )
 except Exception as exc:
     if exc.__class__.__name__ == "QtBindingsNotFoundError":
-        raise ImportError("No Qt binding found, please install PyQt6, PyQt5, PySide6, or PySide2") from None
+        raise ImportError(
+            "No Qt binding found, please install PyQt6, PyQt5, PySide6, or PySide2"
+        ) from None
     else:
         raise
 

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -21,18 +21,26 @@ import os
 from os.path import getsize
 
 import numpy as np
-from qtpy.QtCore import (
-    QEvent,
-    QThread,
-    Qt,
-    Signal,
-    QRectF,
-    QLineF,
-    QPointF,
-    QPoint,
-    QSettings,
-    QSignalBlocker,
-)
+
+try:
+    from qtpy.QtCore import (
+        QEvent,
+        QThread,
+        Qt,
+        Signal,
+        QRectF,
+        QLineF,
+        QPointF,
+        QPoint,
+        QSettings,
+        QSignalBlocker,
+    )
+except Exception as exc:
+    if exc.__class__.__name__ == "QtBindingsNotFoundError":
+        raise ImportError("No Qt binding found, please install pyqt5") from None
+    else:
+        raise exc
+
 from qtpy.QtGui import (
     QFont,
     QIcon,

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -37,7 +37,7 @@ try:
     )
 except Exception as exc:
     if exc.__class__.__name__ == "QtBindingsNotFoundError":
-        raise ImportError("No Qt binding found, please install pyqt5") from None
+        raise ImportError("No Qt binding found, please install PyQt6, PyQt5, PySide6, or PySide2") from None
     else:
         raise exc
 

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -39,7 +39,7 @@ except Exception as exc:
     if exc.__class__.__name__ == "QtBindingsNotFoundError":
         raise ImportError("No Qt binding found, please install PyQt6, PyQt5, PySide6, or PySide2") from None
     else:
-        raise exc
+        raise
 
 from qtpy.QtGui import (
     QFont,

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -35,7 +35,6 @@ except Exception as exc:
  from qtpy.QtCore import (
     QEvent,
     QThread,
-    Qt,
     Signal,
     QRectF,
     QLineF,

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -32,7 +32,7 @@ except Exception as exc:
     else:
         raise
 
- from qtpy.QtCore import (
+from qtpy.QtCore import (
     QEvent,
     QThread,
     Signal,


### PR DESCRIPTION
Related to #199, this PR checks before the first qtpy import if the `QtBindingsNotFoundError` exception is thrown. The error message now hints that pyqt5 needs to be installed.