### PR TITLE
Remove fixes for MNE < 1.0

### DIFF
--- a/mne_qt_browser/_fixes.py
+++ b/mne_qt_browser/_fixes.py
@@ -14,8 +14,8 @@ try:
     from pytestqt.exceptions import capture_exceptions
 except ImportError:
     logger.debug(
-        "If pytest-qt is not installed, errors from inside the event loop will be occluded "
-        "and it will be harder to trace back the cause."
+        "If pytest-qt is not installed, errors from inside the event loop will be "
+        "occluded and it will be harder to trace back the cause."
     )
 
     @contextmanager

--- a/mne_qt_browser/_fixes.py
+++ b/mne_qt_browser/_fixes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Backports for MNE versions (mostly)."""
+"""Backports for older installations."""
 
 # Author: Martin Schulz <dev@earthman-music.de>
 #
@@ -10,80 +10,15 @@ import sys
 from contextlib import contextmanager
 
 from mne.utils import logger
+from mne.viz.backends._utils import _init_mne_qtapp, _qt_raise_window
 
-###############################################################################
-# MNE 1.0+
-try:
-    from mne.viz.backends._utils import _qt_raise_window
-except ImportError:
-
-    def _qt_raise_window(win):
-        try:
-            from matplotlib import rcParams
-
-            raise_window = rcParams["figure.raise_window"]
-        except ImportError:
-            raise_window = True
-        if raise_window:
-            win.activateWindow()
-            win.raise_()
-
-
-try:
-    from mne.viz.backends._utils import _init_mne_qtapp
-except ImportError:
-    from mne.viz.backends._utils import _init_qt_resources
-
-    def _init_mne_qtapp(enable_icon=True, pg_app=False):
-        """Get QApplication-instance for MNE-Python.
-
-        Parameter
-        ---------
-        enable_icon: bool
-            If to set an MNE-icon for the app.
-        pg_app: bool
-            If to create the QApplication with pyqtgraph. For an until know
-            undiscovered reason the pyqtgraph-browser won't show without
-            mkQApp from pyqtgraph.
-
-        Returns
-        -------
-        app: ``qtpy.QtWidgets.QApplication``
-            Instance of QApplication.
-        """
-        from qtpy.QtGui import QIcon
-        from qtpy.QtWidgets import QApplication
-
-        app_name = "MNE-Python"
-        organization_name = "MNE"
-
-        if pg_app:
-            from pyqtgraph import mkQApp
-
-            app = mkQApp(app_name)
-        else:
-            app = QApplication.instance() or QApplication(sys.argv or [app_name])
-            app.setApplicationName(app_name)
-        app.setOrganizationName(organization_name)
-
-        if enable_icon:
-            # Set icon
-            _init_qt_resources()
-            kind = "bigsur-" if platform.mac_ver()[0] >= "10.16" else ""
-            app.setWindowIcon(QIcon(f":/mne-{kind}icon.png"))
-
-        return app
-
-
-###############################################################################
 # pytestqt
 try:
     from pytestqt.exceptions import capture_exceptions
 except ImportError:
     logger.debug(
-        "If pytest-qt is not installed, the errors from inside "
-        "the Qt-loop will be occluded and it will be harder "
-        "to trace back the cause."
+        "If pytest-qt is not installed, errors from inside the event loop will be occluded "
+        "and it will be harder to trace back the cause."
     )
 
     @contextmanager

--- a/mne_qt_browser/_fixes.py
+++ b/mne_qt_browser/_fixes.py
@@ -5,12 +5,9 @@
 #
 # License: BSD-3-Clause
 
-import platform
-import sys
 from contextlib import contextmanager
 
 from mne.utils import logger
-from mne.viz.backends._utils import _init_mne_qtapp, _qt_raise_window
 
 # pytestqt
 try:

--- a/mne_qt_browser/_fixes.py
+++ b/mne_qt_browser/_fixes.py
@@ -57,18 +57,6 @@ except ImportError:
         app_name = "MNE-Python"
         organization_name = "MNE"
 
-        # Fix from cbrnr/mnelab for app name in menu bar
-        if sys.platform.startswith("darwin"):
-            try:
-                # set bundle name on macOS (app name shown in the menu bar)
-                from Foundation import NSBundle
-
-                bundle = NSBundle.mainBundle()
-                info = bundle.localizedInfoDictionary() or bundle.infoDictionary()
-                info["CFBundleName"] = app_name
-            except ModuleNotFoundError:
-                pass
-
         if pg_app:
             from pyqtgraph import mkQApp
 

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -43,6 +43,7 @@ from mne.io.pick import _DATA_CH_TYPES_ORDER_DEFAULT, _DATA_CH_TYPES_SPLIT
 from mne.utils import _check_option, _to_rgb, get_config, logger, sizeof_fmt, warn
 from mne.viz import plot_sensors
 from mne.viz._figure import BrowserBase
+from mne.viz.backends._utils import _init_mne_qtapp, _qt_raise_window
 from mne.viz.utils import _figure_agg, _merge_annotations, _simplify_float
 from pyqtgraph import (
     AxisItem,
@@ -126,7 +127,7 @@ from qtpy.QtWidgets import (
 from scipy.stats import zscore
 
 from . import _browser_instances
-from ._fixes import _init_mne_qtapp, _qt_raise_window, capture_exceptions
+from ._fixes import capture_exceptions
 
 name = "pyqtgraph"
 


### PR DESCRIPTION
Setting the app name in the macOS menu bar is an ugly hack I just realized. The issue is that it overwrites any previously set name, so once again, starting MNE-Qt-Browser from MNELAB changes the name from "MNELAB" to "MNE-Python".

Since (1) this is a hack and (2) it is not really necessary to change the name for MNE-Qt-Browser (the default is "Python"), I would like to remove it.