### PR TITLE
MAINT: Remove packaging as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
   "Programming Language :: Python",
 ]
 dependencies = [
-  "packaging",
   "numpy",
   "scipy",
   "matplotlib",


### PR DESCRIPTION
https://github.com/conda-forge/mne-qt-browser-feedstock/pull/29 pointed out we don't use `packaging` anymore so let's get rid of it in `pyproject.toml`