### PR TITLE
Fix project urls in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ tests = [
 ]
 
 [project.urls]
-homepage = "https://github.com/mne-tools/mne-qt-browser"
+homepage = "https://mne.tools/"
 repository = "https://github.com/mne-tools/mne-qt-browser"
 changelog = "https://github.com/mne-tools/mne-qt-browser/releases"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,9 @@ tests = [
 ]
 
 [project.urls]
-homepage = "https://mne.tools/mne-bids-pipeline"
-repository = "https://github.com/mne-tools/mne-bids-pipeline"
-changelog = "http://github.com/mne-tools/mne-qt-browser/releases"
+homepage = "https://github.com/mne-tools/mne-qt-browser"
+repository = "https://github.com/mne-tools/mne-qt-browser"
+changelog = "https://github.com/mne-tools/mne-qt-browser/releases"
 
 [tool.hatch.build]
 exclude = [


### PR DESCRIPTION
Sorry for not creating an issue first, I was a bit lazy and I was hoping this would be okay since there is no change to the actual code.

I noticed that the project urls "homepage" and "repository" were pointing to mne-bids-pipeline and not mne-qt-browser (these links appear for example on the PyPi release page). 
I fixed the repository url, but don't think there is a homepage, right? An option might be to just remove the homepage url if there isn't any. I made it also point to the GitHub repo for the moment.
Additionally I changed "changelog" to an https not http url.