### PR TITLE
Enh ch type scale display

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -116,6 +116,7 @@ from qtpy.QtWidgets import (
     QScrollBar,
     QSizePolicy,
     QSlider,
+    QSpacerItem,
     QSpinBox,
     QStyle,
     QStyleOptionSlider,
@@ -1802,10 +1803,9 @@ class SettingsDialog(_BaseDialog):
         layout.addRow("horizontal scroll sensitivity", self.scroll_sensitivity_slider)
 
         # Add subgroup box to show channel type scalings
+        layout.addItem(QSpacerItem(10, 10, QSizePolicy.Minimum, QSizePolicy.Expanding))
         ch_scaling_box = QGroupBox("Channel Type Scalings")
-        # self.mne.unit_scalings
-        # self.mne.scalings
-        # self.mne.units
+        ch_scaling_box.setStyleSheet("QGroupBox { font-size: 12pt; }")
         ch_scaling_layout = QFormLayout()
         self.ch_scaling_spinboxes = {}
 

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -101,6 +101,7 @@ from qtpy.QtWidgets import (
     QGraphicsScene,
     QGraphicsView,
     QGridLayout,
+    QGroupBox,
     QHBoxLayout,
     QInputDialog,
     QLabel,
@@ -1799,6 +1800,33 @@ class SettingsDialog(_BaseDialog):
         # Set default
         self.scroll_sensitivity_slider.setValue(self.mne.scroll_sensitivity)
         layout.addRow("horizontal scroll sensitivity", self.scroll_sensitivity_slider)
+
+        # Add subgroup box to show channel type scalings
+        ch_scaling_box = QGroupBox("Channel Type Scalings")
+        # self.mne.unit_scalings
+        # self.mne.scalings
+        # self.mne.units
+        ch_scaling_layout = QFormLayout()
+        self.ch_scaling_spinboxes = {}
+
+        # Get all unique channel types
+        ordered_types = self.mne.ch_types[self.mne.ch_order]
+        unique_type_idxs = np.unique(ordered_types, return_index=True)[1]
+        ch_types_ordered = [ordered_types[idx] for idx in sorted(unique_type_idxs)]
+        for ch in ch_types_ordered:
+            if ch in self.mne.unit_scalings.keys():
+                ch_spinbox = QDoubleSpinBox()
+                ch_spinbox.setRange(-float("inf"), float("inf"))
+                ch_spinbox.setDecimals(3)
+                ch_spinbox.setValue(self.mne.scalings[ch] * self.mne.unit_scalings[ch])
+                ch_spinbox.setDisabled(True)
+                # ch_spinbox.setReadOnly(True)
+                ch_spinbox.setMinimumWidth(150)
+                self.ch_scaling_spinboxes[ch] = ch_spinbox
+                ch_scaling_layout.addRow(f"{ch} ({self.mne.units[ch]})", ch_spinbox)
+
+        ch_scaling_box.setLayout(ch_scaling_layout)
+        layout.addRow(ch_scaling_box)
 
         self.setLayout(layout)
         self.show()


### PR DESCRIPTION
Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/install/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value all user
contributions, no matter how minor they are. If we are slow to review, either
the pull request needs some benchmarking, tinkering, convincing, etc. or more
likely the reviewers are simply busy. In either case, we ask for your
understanding during the review process.

Again, thanks for contributing!

#### Reference issue

https://github.com/mne-tools/mne-qt-browser/pull/230 , https://github.com/mne-tools/mne-python/issues/10888 , https://github.com/mne-tools/mne-qt-browser/pull/212


#### What does this implement/fix?

Adds to the Settings dialogue to display channel scalings and channel units
<img width="324" alt="Screenshot 2024-06-29 at 11 49 42 AM" src="https://github.com/mne-tools/mne-qt-browser/assets/34498671/1e58e5d4-f8cb-4f87-b7ba-c04dff1ca380">

Currently the spinboxes can't be edited and will not be able to until a following PR. Let me know if they style of the groupbox containing the channel scalings should change (such as putting units after the spinbox)

#### Additional information

This is the first of 4 or 5 PRs to allow display and scaling of channel types based on sensor units and monitor resolution and size
