### PR TITLE
channel scaling spinboxes update

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -4758,6 +4758,7 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
         self.mne.butterfly = butterfly
         self._update_picks()
         self._update_data()
+        self._update_ch_spinbox_values()
 
         if butterfly and self.mne.fig_selection is not None:
             self.mne.selection_ypos_dict.clear()

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -87,6 +87,7 @@ from qtpy.QtGui import (
 )
 from qtpy.QtTest import QTest
 from qtpy.QtWidgets import (
+    QAbstractSpinBox,
     QAction,
     QActionGroup,
     QApplication,
@@ -1823,10 +1824,10 @@ class SettingsDialog(_BaseDialog):
             if ch in self.mne.unit_scalings.keys():
                 ch_spinbox = QDoubleSpinBox()
                 ch_spinbox.setMinimumWidth(100)
-                ch_spinbox.setRange(-float("inf"), float("inf"))
+                ch_spinbox.setRange(0, float("inf"))
                 ch_spinbox.setDecimals(1)
+                ch_spinbox.setStepType(QAbstractSpinBox.AdaptiveDecimalStepType)
                 inv_norm = _get_channel_scaling(self, ch)
-                ch_spinbox.setSingleStep(inv_norm * 0.25)
                 ch_spinbox.setValue(inv_norm)
                 ch_spinbox.valueChanged.connect(
                     _methpartial(self._update_spinbox_values, ch_type=ch)
@@ -3949,8 +3950,6 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
         self._update_scalebar_values()
         if self.mne.fig_settings is not None:
             self.mne.fig_settings._update_spinbox_values()
-
-        # self._update_ch_spinbox_values()
 
     def hscroll(self, step):
         """Scroll horizontally by step."""

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -1825,8 +1825,9 @@ class SettingsDialog(_BaseDialog):
                 ch_spinbox.setMinimumWidth(100)
                 ch_spinbox.setRange(-float("inf"), float("inf"))
                 ch_spinbox.setDecimals(1)
-                ch_spinbox.setSingleStep(50)
-                ch_spinbox.setValue(self._get_scaling_value(ch_type=ch))
+                inv_norm = _get_channel_scaling(self, ch)
+                ch_spinbox.setSingleStep(inv_norm * 0.1)
+                ch_spinbox.setValue(inv_norm)
                 ch_spinbox.valueChanged.connect(
                     _methpartial(self._update_spinbox_values, ch_type=ch)
                 )

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -1810,7 +1810,7 @@ class SettingsDialog(_BaseDialog):
         self.ch_scaling_spinboxes = {}
 
         # Get all unique channel types and allow scaling
-        self.scaler = 1 if self.mne.butterfly else 2
+        scaler = 1 if self.mne.butterfly else 2
         ordered_types = self.mne.ch_types[self.mne.ch_order]
         unique_type_idxs = np.unique(ordered_types, return_index=True)[1]
         ch_types_ordered = [ordered_types[idx] for idx in sorted(unique_type_idxs)]
@@ -1823,7 +1823,7 @@ class SettingsDialog(_BaseDialog):
                 ch_spinbox.setValue(
                     self.mne.scalings[ch]
                     * self.mne.unit_scalings[ch]
-                    * self.scaler
+                    * scaler
                     / self.mne.scale_factor
                 )
                 ch_spinbox.valueChanged.connect(
@@ -1859,11 +1859,12 @@ class SettingsDialog(_BaseDialog):
 
     def _update_spinbox_values(self, *args, **kwargs):
         """Update spinbox values."""
+        scaler = 1 if self.mne.butterfly else 2
         if len(args) > 0:
             new_value = args[0]
             ch_type = kwargs["ch_type"]
             self.mne.scalings[ch_type] = new_value / (
-                self.mne.unit_scalings[ch_type] * self.scaler / self.mne.scale_factor
+                self.mne.unit_scalings[ch_type] * scaler / self.mne.scale_factor
             )
             self.mne.scalebar_texts[ch_type].update_value()
             self.weakmain()._redraw()
@@ -1872,7 +1873,7 @@ class SettingsDialog(_BaseDialog):
                 spinbox.setValue(
                     self.mne.scalings[ch_type]
                     * self.mne.unit_scalings[ch_type]
-                    * self.scaler
+                    * scaler
                     / self.mne.scale_factor
                 )
 

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -1853,6 +1853,7 @@ class SettingsDialog(_BaseDialog):
 
     def _ch_scaling_changed(self, new_value, ch_type):
         self.mne.scalings[ch_type] = new_value / self.mne.unit_scalings[ch_type]
+        self.mne.scalebar_texts[ch_type].update_value()
         self.weakmain()._redraw()
 
 

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -1826,7 +1826,7 @@ class SettingsDialog(_BaseDialog):
                 ch_spinbox.setRange(-float("inf"), float("inf"))
                 ch_spinbox.setDecimals(1)
                 inv_norm = _get_channel_scaling(self, ch)
-                ch_spinbox.setSingleStep(inv_norm * 0.1)
+                ch_spinbox.setSingleStep(inv_norm * 0.25)
                 ch_spinbox.setValue(inv_norm)
                 ch_spinbox.valueChanged.connect(
                     _methpartial(self._update_spinbox_values, ch_type=ch)

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -1810,6 +1810,7 @@ class SettingsDialog(_BaseDialog):
         self.ch_scaling_spinboxes = {}
 
         # Get all unique channel types and allow scaling
+        self.scaler = 1 if self.mne.butterfly else 2
         ordered_types = self.mne.ch_types[self.mne.ch_order]
         unique_type_idxs = np.unique(ordered_types, return_index=True)[1]
         ch_types_ordered = [ordered_types[idx] for idx in sorted(unique_type_idxs)]
@@ -1819,7 +1820,12 @@ class SettingsDialog(_BaseDialog):
                 ch_spinbox.setMinimumWidth(100)
                 ch_spinbox.setRange(-float("inf"), float("inf"))
                 ch_spinbox.setDecimals(1)
-                ch_spinbox.setValue(self.mne.scalings[ch] * self.mne.unit_scalings[ch])
+                ch_spinbox.setValue(
+                    self.mne.scalings[ch]
+                    * self.mne.unit_scalings[ch]
+                    * self.scaler
+                    * self.mne.scale_factor
+                )
                 ch_spinbox.valueChanged.connect(
                     _methpartial(self._ch_scaling_changed, ch_type=ch)
                 )
@@ -1852,7 +1858,9 @@ class SettingsDialog(_BaseDialog):
         self.weakmain()._toggle_antialiasing()
 
     def _ch_scaling_changed(self, new_value, ch_type):
-        self.mne.scalings[ch_type] = new_value / self.mne.unit_scalings[ch_type]
+        self.mne.scalings[ch_type] = new_value / (
+            self.mne.unit_scalings[ch_type] * self.scaler * self.mne.scale_factor
+        )
         self.mne.scalebar_texts[ch_type].update_value()
         self.weakmain()._redraw()
 

--- a/mne_qt_browser/tests/test_pg_specific.py
+++ b/mne_qt_browser/tests/test_pg_specific.py
@@ -277,6 +277,24 @@ def test_pg_settings_dialog(raw_orig, pg_backend):
     assert sensitivities_mne == sensitivity_values
     assert sensitivities_control == sensitivity_values
 
+    ordered_types = fig.mne.ch_types[fig.mne.ch_order]
+    unique_types = np.unique(ordered_types)
+    unique_types = [
+        ch_type for ch_type in unique_types if ch_type in fig.mne.unit_scalings.keys()
+    ]
+    n_unique_types = len(unique_types)
+    assert n_unique_types == len(fig.mne.fig_settings.ch_scaling_spinboxes)
+
+    ch_type_test = unique_types[0]
+    ch_spinbox = fig.mne.fig_settings.ch_scaling_spinboxes[ch_type_test]
+    inv_norm = (
+        fig.mne.scalings[ch_type_test]
+        * fig.mne.unit_scalings[ch_type_test]
+        * 2  # values multiplied by two for raw data
+        / fig.mne.scale_factor
+    )
+    assert inv_norm == ch_spinbox.value()
+
 
 def test_pg_help_dialog(raw_orig, pg_backend):
     """Test Settings Dialog toggle on/off for pyqtgraph-backend."""


### PR DESCRIPTION
<!--

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/install/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value all user
contributions, no matter how minor they are. If we are slow to review, either
the pull request needs some benchmarking, tinkering, convincing, etc. or more
likely the reviewers are simply busy. In either case, we ask for your
understanding during the review process.

Again, thanks for contributing!

-->

#### Reference issue

https://github.com/mne-tools/mne-qt-browser/pull/230 , https://github.com/mne-tools/mne-python/issues/10888 , https://github.com/mne-tools/mne-qt-browser/pull/212

#### What does this implement/fix?

Spinboxes in channel scalings within Settings can now be updated

![Screenshot 2024-07-02 at 2 05 50 PM](https://github.com/mne-tools/mne-qt-browser/assets/34498671/4c024af9-208e-4286-9ef9-f86a36856c1e)


#### Additional information

This is the second of 4 or 5 PRs to allow display and scaling of channel types based on sensor units and monitor resolution and size