### PR TITLE
BUG: Fix bug with over-updating and antialias toggle

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -1743,10 +1743,10 @@ class SettingsDialog(_BaseDialog):
         # Antialiasing
         self.antialiasing_box = QCheckBox()
         self.antialiasing_box.setToolTip("Enable/Disable antialiasing.\n")
+        self.antialiasing_box.setChecked(self.mne.antialiasing)
         self.antialiasing_box.stateChanged.connect(
             _methpartial(self._toggle_antialiasing)
         )
-        self.antialiasing_box.setChecked(self.mne.antialiasing)
         layout.addRow("antialiasing", self.antialiasing_box)
 
         # Downsampling
@@ -1761,11 +1761,11 @@ class SettingsDialog(_BaseDialog):
         )
         self.downsampling_box.setMinimum(0)
         self.downsampling_box.setSpecialValueText("Auto")
-        self.downsampling_box.valueChanged.connect(
-            _methpartial(self._value_changed, value_name="downsampling")
-        )
         self.downsampling_box.setValue(
             0 if self.mne.downsampling == "auto" else self.mne.downsampling
+        )
+        self.downsampling_box.valueChanged.connect(
+            _methpartial(self._value_changed, value_name="downsampling")
         )
         layout.addRow("downsampling", self.downsampling_box)
 
@@ -1787,10 +1787,10 @@ class SettingsDialog(_BaseDialog):
             'Default is "peak".'
         )
         self.ds_method_cmbx.addItems(["subsample", "mean", "peak"])
+        self.ds_method_cmbx.setCurrentText(self.mne.ds_method)
         self.ds_method_cmbx.currentTextChanged.connect(
             _methpartial(self._value_changed, value_name="ds_method")
         )
-        self.ds_method_cmbx.setCurrentText(self.mne.ds_method)
         layout.addRow("ds_method", self.ds_method_cmbx)
 
         # Scrolling sensitivity
@@ -1802,11 +1802,11 @@ class SettingsDialog(_BaseDialog):
             "Adjust this value if the scrolling for example with an horizontal "
             "mouse wheel is too fast or too slow. Default is 100."
         )
+        self.scroll_sensitivity_slider.setValue(self.mne.scroll_sensitivity)
         self.scroll_sensitivity_slider.valueChanged.connect(
             _methpartial(self._value_changed, value_name="scroll_sensitivity")
         )
         # Set default
-        self.scroll_sensitivity_slider.setValue(self.mne.scroll_sensitivity)
         layout.addRow("horizontal scroll sensitivity", self.scroll_sensitivity_slider)
 
         # Add subgroup box to show channel type scalings


### PR DESCRIPTION
In finding #270 I noticed that just opening the Settings dialog triggered 3 updates. There is no reason this is necessary, and is an unnecessary slowdown. It happens because we connect the listener then set the value (to it's currently used value)... which triggers an update.

And this is a bug for `antialiasing` actually because it triggers an AA toggle, so if you had AA on, it connected the listener, set the `setChecked(True)` which initiated a toggle, *disabling* AA. So the check state was always out of phase with the actual state.