### PR TITLE
Fix annotation of last sample

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -3261,7 +3261,7 @@ class AnnotationDock(QDockWidget):
         start = self.start_bx.value()
         sel_region = self.mne.selected_region
         stop = sel_region.getRegion()[1]
-        if start < stop:
+        if start <= stop:
             self.mne.selected_region.setRegion((start, stop))
             # Make channel specific fillBetweens stay in sync with annot region
             # if len(sel_region.single_channel_annots.keys()) > 0:
@@ -3269,7 +3269,7 @@ class AnnotationDock(QDockWidget):
         else:
             self.weakmain().message_box(
                 text="Invalid value!",
-                info_text="Start can't be bigger or equal to Stop!",
+                info_text="Start can't be bigger than Stop!",
                 icon=QMessageBox.Critical,
                 modal=False,
             )
@@ -3279,12 +3279,12 @@ class AnnotationDock(QDockWidget):
         stop = self.stop_bx.value()
         sel_region = self.mne.selected_region
         start = sel_region.getRegion()[0]
-        if start < stop:
+        if start <= stop:
             sel_region.setRegion((start, stop))
         else:
             self.weakmain().message_box(
                 text="Invalid value!",
-                info_text="Stop can't be smaller or equal to Start!",
+                info_text="Stop can't be smaller than Start!",
                 icon=QMessageBox.Critical,
             )
             self.stop_bx.setValue(sel_region.getRegion()[1])

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -1437,9 +1437,8 @@ class RawViewBox(ViewBox):
                 elif event.isFinish():
                     drag_stop = self.mapSceneToView(event.scenePos()).x()
                     drag_stop = 0 if drag_stop < 0 else drag_stop
-                    drag_stop = (
-                        self.mne.xmax if self.mne.xmax < drag_stop else drag_stop
-                    )
+                    xmax = self.mne.xmax + 1 / self.mne.info["sfreq"]
+                    drag_stop = xmax if xmax < drag_stop else drag_stop
                     self._drag_region.setRegion((self._drag_start, drag_stop))
                     plot_onset = min(self._drag_start, drag_stop)
                     plot_offset = max(self._drag_start, drag_stop)
@@ -2659,7 +2658,7 @@ class AnnotRegion(LinearRegionItem):
             orientation="vertical",
             movable=True,
             swapMode="sort",
-            bounds=(0, mne.xmax),
+            bounds=(0, mne.xmax + 1 / mne.info["sfreq"]),
         )
         # Set default z-value to 0 to be behind other items in scene
         self.setZValue(0)
@@ -3035,7 +3034,7 @@ class AnnotationDock(QDockWidget):
         self.start_bx = QDoubleSpinBox()
         self.start_bx.setDecimals(time_decimals)
         self.start_bx.setMinimum(0)
-        self.start_bx.setMaximum(self.mne.xmax - 1 / self.mne.info["sfreq"])
+        self.start_bx.setMaximum(self.mne.xmax)
         self.start_bx.setSingleStep(0.05)
         self.start_bx.valueChanged.connect(self._start_changed)
         layout.addWidget(self.start_bx)
@@ -3043,8 +3042,8 @@ class AnnotationDock(QDockWidget):
         layout.addWidget(QLabel("Stop:"))
         self.stop_bx = QDoubleSpinBox()
         self.stop_bx.setDecimals(time_decimals)
-        self.stop_bx.setMinimum(1 / self.mne.info["sfreq"])
-        self.stop_bx.setMaximum(self.mne.xmax)
+        self.stop_bx.setMinimum(0)
+        self.stop_bx.setMaximum(self.mne.xmax + 1 / self.mne.info["sfreq"])
         self.stop_bx.setSingleStep(0.05)
         self.stop_bx.valueChanged.connect(self._stop_changed)
         layout.addWidget(self.stop_bx)


### PR DESCRIPTION
#### Reference issue

Fixes issue #12893 in mne-python (https://github.com/mne-tools/mne-python/issues/12893)
The issue is also discussed in PR #12895 in mne-python (https://github.com/mne-tools/mne-python/pull/12895)

#### What does this implement/fix?

Currently, when annotating bad epochs in mne-qt-browser, annotations were limited to the last sample of the recording, so that the last sample of the recording would not actually be rejected.
This fixes this issue, and additionally allows for 1-sample annotations at the start (t=0) and end (t=xmax) of the recording.

- raise upper limit of RawViewBox to xmax + 1 sample, so that new annotations can extend above the recording
- raise upper limit of AnnotRegion to xmax + 1 sample for all annotations
- to allow for 1-sample annotations at the beginning (0) and end (xmax) of recording in the AnnotationDock :
    - raise maximum of an annotation start to xmax
    - lower the minimum of an annotation end/stop to 0
    - raise maximum of an annotation end to xmax + 1 sample