### PR TITLE
Enhance Help Menu for Better Functionality Discoverability

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -4236,7 +4236,6 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
 
     def create_menus(self):
         """Creates and returns the application's menu bar with properly aligned shortcuts."""
-
         if not self.menuBar():
             self.setMenuBar(QMenuBar(self))
         menu_bar = self.menuBar()
@@ -4272,7 +4271,6 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
                 ("Toggle Events visibility     ", "E"),
                 ("Toggle Projection Figure / all projections     ", "J"),
             ],
-
             view_menu: [
                 ("Add/remove channels     ", "Shift + Click"),
                 ("Decrease duration (¼ page)     ", "Home"),
@@ -4291,13 +4289,11 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
                 ("Toggle Crosshair     ", "X"),
                 ("Toggle Zen Mode     ", "Z"),
             ],
-
             help_menu: [
                 ("Show Help     ", "?"),
                 ("Toggle Fullscreen     ", "F11"),
                 ("Close     ", "Escape"),
             ],
-
             scroll_menu: [
                 ("Scroll left (¼ page/full page)     ", "← / →"),
                 ("Scroll up (full page)     ", "↑"),

--- a/mne_qt_browser/tests/test_pg_specific.py
+++ b/mne_qt_browser/tests/test_pg_specific.py
@@ -486,6 +486,7 @@ def test_pg_settings_dialog(raw_orig, pg_backend):
     fig.resize(orig_window_size.width() * 2, orig_window_size.height() * 2)
     assert ch_sens_spinbox.value() != orig_sens
 
+
 def test_pg_toolbar_time_plus_minus(raw_orig, pg_backend):
     """Test time controls."""
     fig = raw_orig.plot()
@@ -650,6 +651,7 @@ def test_pg_toolbar_actions(raw_orig, pg_backend):
     assert pg_backend._get_n_figs() == 3
     fig._fake_click_on_toolbar_action("Settings", wait_after=100)
     assert pg_backend._get_n_figs() == 2
+
 
 # LAB values taken from colorspacious on 2024/06/10
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/install/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value all user
contributions, no matter how minor they are. If we are slow to review, either
the pull request needs some benchmarking, tinkering, convincing, etc. or more
likely the reviewers are simply busy. In either case, we ask for your
understanding during the review process.

Again, thanks for contributing!

-->

#### Reference issue

Example: Fixes #84 

#### What does this fix?

This PR improves the Help menu by replacing the old HelpDialog with a simpler and more accessible menu. Now, users can find keyboard and mouse shortcuts directly in a dropdown menu instead of a separate dialog.

Key changes
- Removed the HelpDialog class.
- Introduced a Help button (QToolButton) for quick access.

#### Additional information

Please review the changes and let me know if there are any improvements or issues that need to be addressed. 

<h4>Here are the screenshots of the UI</h4>

![image](https://github.com/user-attachments/assets/0a6c8b55-b4b0-4903-94f4-fdaf29c1fd96)

![image](https://github.com/user-attachments/assets/12711928-ebc0-407d-8127-bc78c19e1ca3)