### PR TITLE
ENH: Make _process_data arg/kwarg agnostic

### DIFF
--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -2650,7 +2650,7 @@ class AnnotRegion(LinearRegionItem):
     removeRequested = Signal(object)
     removeSingleChannelAnnots = Signal(object)
     sigToggleVisibility = Signal(bool)
-    sigUpdateColor = Signal(str)
+    sigUpdateColor = Signal(str | tuple)
 
     def __init__(self, mne, description, values, weakmain, ch_names=None):
         super().__init__(

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -2650,7 +2650,7 @@ class AnnotRegion(LinearRegionItem):
     removeRequested = Signal(object)
     removeSingleChannelAnnots = Signal(object)
     sigToggleVisibility = Signal(bool)
-    sigUpdateColor = Signal(str | tuple)
+    sigUpdateColor = Signal(object)  # can be str or tuple
 
     def __init__(self, mne, description, values, weakmain, ch_names=None):
         super().__init__(

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -4704,6 +4704,12 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
             times = self.mne.times
             data = self.mne.data
             n_ch = data.shape[0]
+            if data.shape[1] % ds != 0:
+                data = np.pad(
+                    data,
+                    ((0, 0), (0, data.shape[1] - (data.shape[1] // ds) * ds)),
+                    mode="edge",
+                )
 
             if self.mne.ds_method == "subsample":
                 times = times[::ds]
@@ -4837,8 +4843,8 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
                 )
                 return False
 
-    def _process_data(self, data, start, stop, picks, signals=None):
-        data = super()._process_data(data, start, stop, picks, signals)
+    def _process_data(self, *args, **kwargs):
+        data = super()._process_data(*args, **kwargs)
 
         # Invert Data to be displayed from top on inverted Y-Axis
         data *= -1

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -4704,12 +4704,6 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
             times = self.mne.times
             data = self.mne.data
             n_ch = data.shape[0]
-            if data.shape[1] % ds != 0:
-                data = np.pad(
-                    data,
-                    ((0, 0), (0, data.shape[1] - (data.shape[1] // ds) * ds)),
-                    mode="edge",
-                )
 
             if self.mne.ds_method == "subsample":
                 times = times[::ds]

--- a/mne_qt_browser/tests/test_pg_specific.py
+++ b/mne_qt_browser/tests/test_pg_specific.py
@@ -337,9 +337,12 @@ def test_pg_settings_dialog(raw_orig, pg_backend):
     # Could be 6008 or 6006 depending on if MNE-Python has
     # https://github.com/mne-tools/mne-qt-browser/pull/320 (1.10+)
     assert fig.mne.data.shape[1] in (6006, 6007, 6008)
-    downsampling_control.setValue(7)  # does not evenly divide into the data length
+    assert (
+        fig.mne.data.shape[1] % 11 != 0
+    )  # does not evenly divide into the data length
+    downsampling_control.setValue(11)
     QTest.qWait(100)
-    assert downsampling_control.value() == 7
+    assert downsampling_control.value() == 11
     assert downsampling_control.value() == fig.mne.downsampling
 
     QTest.qWait(100)

--- a/mne_qt_browser/tests/test_pg_specific.py
+++ b/mne_qt_browser/tests/test_pg_specific.py
@@ -336,7 +336,7 @@ def test_pg_settings_dialog(raw_orig, pg_backend):
 
     # Could be 6008 or 6006 depending on if MNE-Python has
     # https://github.com/mne-tools/mne-qt-browser/pull/320 (1.10+)
-    assert fig.mne.data.shape[1] in (6006, 6008)
+    assert fig.mne.data.shape[1] in (6006, 6007, 6008)
     downsampling_control.setValue(7)  # does not evenly divide into the data length
     QTest.qWait(100)
     assert downsampling_control.value() == 7

--- a/mne_qt_browser/tests/test_pg_specific.py
+++ b/mne_qt_browser/tests/test_pg_specific.py
@@ -334,9 +334,10 @@ def test_pg_settings_dialog(raw_orig, pg_backend):
     assert downsampling_control.value() == 2
     assert downsampling_control.value() == fig.mne.downsampling
 
-    downsampling_control.setValue(3)
+    assert fig.mne.data.shape[1] == 6006
+    downsampling_control.setValue(7)  # does not evenly divide into the data length
     QTest.qWait(100)
-    assert downsampling_control.value() == 3
+    assert downsampling_control.value() == 7
     assert downsampling_control.value() == fig.mne.downsampling
 
     QTest.qWait(100)
@@ -347,16 +348,22 @@ def test_pg_settings_dialog(raw_orig, pg_backend):
     QTest.qWait(100)
     assert downsampling_method_control.currentText() == "mean"
     assert fig.mne.ds_method == "mean"
+    fig._redraw(update_data=True)  # make sure it works
+    assert fig.mne.data.shape[-1] == len(fig.mne.times)
 
     downsampling_method_control.setCurrentText("subsample")
     QTest.qWait(100)
     assert downsampling_method_control.currentText() == "subsample"
     assert fig.mne.ds_method == "subsample"
+    fig._redraw(update_data=True)  # make sure it works
+    assert fig.mne.data.shape[-1] == len(fig.mne.times)
 
     downsampling_method_control.setCurrentText("peak")
     QTest.qWait(100)
     assert downsampling_method_control.currentText() == "peak"
     assert fig.mne.ds_method == "peak"
+    fig._redraw(update_data=True)  # make sure it works
+    assert fig.mne.data.shape[-1] == len(fig.mne.times)
 
     downsampling_method_control.setCurrentText("invalid_method_name")
     QTest.qWait(100)

--- a/mne_qt_browser/tests/test_pg_specific.py
+++ b/mne_qt_browser/tests/test_pg_specific.py
@@ -334,7 +334,9 @@ def test_pg_settings_dialog(raw_orig, pg_backend):
     assert downsampling_control.value() == 2
     assert downsampling_control.value() == fig.mne.downsampling
 
-    assert fig.mne.data.shape[1] == 6006
+    # Could be 6008 or 6006 depending on if MNE-Python has
+    # https://github.com/mne-tools/mne-qt-browser/pull/320 (1.10+)
+    assert fig.mne.data.shape[1] in (6006, 6008)
     downsampling_control.setValue(7)  # does not evenly divide into the data length
     QTest.qWait(100)
     assert downsampling_control.value() == 7


### PR DESCRIPTION
This allows the extra-data-loading gymnastics in https://github.com/mne-tools/mne-python/pull/13183. Also adds a little test that the downsampling stuff actually works (I wasn't sure looking at the code at first).