### PR TITLE
BUG: Fix bug with PySide 6.9.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.2
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: ["--fix"]
       - id: ruff-format
 

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -2348,10 +2348,10 @@ class ProjDialog(_BaseDialog):
         self.setLayout(layout)
         self.show()
 
-    def _proj_changed(self, state, idx):
+    def _proj_changed(self, state=None, idx=None):
         # Only change if proj wasn't already applied.
         if not self.mne.projs_active[idx]:
-            self.mne.projs_on[idx] = state
+            self.mne.projs_on[idx] = not self.mne.projs_on[idx]
             self.weakmain()._apply_update_projectors()
 
     def toggle_all(self):


### PR DESCRIPTION
The event no longer passes a `state` I guess, so let's not require it.