### PR TITLE
Use step size of 1 to increase/decrease channels

### DIFF
--- a/src/mne_qt_browser/_pg_figure.py
+++ b/src/mne_qt_browser/_pg_figure.py
@@ -568,14 +568,14 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
             text="Show fewer channels",
             parent=self,
         )
-        adecr_nchan.triggered.connect(_methpartial(self.change_nchan, step=-10))
+        adecr_nchan.triggered.connect(_methpartial(self.change_nchan, step=-1))
         self.mne.toolbar.addAction(adecr_nchan)
         aincr_nchan = QAction(
             icon=self._qicon("more_channels"),
             text="Show more channels",
             parent=self,
         )
-        aincr_nchan.triggered.connect(_methpartial(self.change_nchan, step=10))
+        aincr_nchan.triggered.connect(_methpartial(self.change_nchan, step=1))
         self.mne.toolbar.addAction(aincr_nchan)
         self.mne.toolbar.addSeparator()
 


### PR DESCRIPTION
Fixes #352. This PR changes the step size to 1 for the toolbar buttons that change the number of shown channels, making it consistent with the PageUp/PageDown keyboard shortcuts.