### PR TITLE
Warn about antialiasing without OpenGL on Linux

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
   "scooby",
   "mne>=1.0",
   "pyqtgraph>=0.12.3",
-  "pyopengl; platform_system=='Linux'",
   "packaging",
   "darkdetect",
   "qdarkstyle",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "scooby",
   "mne>=1.0",
   "pyqtgraph>=0.12.3",
-  "pyopengl; platform_system=='Darwin'",
+  "pyopengl; platform_system=='Linux'",
   "packaging",
   "darkdetect",
   "qdarkstyle",

--- a/src/mne_qt_browser/_pg_figure.py
+++ b/src/mne_qt_browser/_pg_figure.py
@@ -496,6 +496,7 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):  # type: i
             platform.system() == "Linux"
             and self.mne.antialiasing
             and not self.mne.use_opengl
+            and not check_version("pyqtgraph", "0.14")
         ):  # pragma: no cover
             warn(
                 "On Linux, antialiasing without OpenGL can result in poor performance. "

--- a/src/mne_qt_browser/_pg_figure.py
+++ b/src/mne_qt_browser/_pg_figure.py
@@ -460,8 +460,7 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):  # type: i
         self._add_scalebars()
 
         # Check for OpenGL
-        # If a user doesn't specify whether or not to use it, disable it (PyOpenGL is an
-        # optional requirement)
+        # If a user doesn't specify whether or not to use it, disable it
         opengl_key = "MNE_BROWSER_USE_OPENGL"
         if self.mne.use_opengl is None:  # default: opt-in
             config_val = get_config(opengl_key, "").lower()

--- a/src/mne_qt_browser/_pg_figure.py
+++ b/src/mne_qt_browser/_pg_figure.py
@@ -467,7 +467,7 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):  # type: i
             config_val = get_config(opengl_key, "").lower()
             self.mne.use_opengl = config_val == "true"
 
-        if self.mne.use_opengl:
+        if self.mne.use_opengl and not check_version("pyqtgraph", "0.14"):
             try:
                 import OpenGL
             except (ModuleNotFoundError, ImportError):

--- a/src/mne_qt_browser/_pg_figure.py
+++ b/src/mne_qt_browser/_pg_figure.py
@@ -222,7 +222,7 @@ class _PGMetaClass(type(QMainWindow), type(BrowserBase)):
     pass
 
 
-class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
+class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):  # type: ignore
     """A PyQtGraph-backend for 2D data browsing."""
 
     gotClosed = Signal()
@@ -460,8 +460,8 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
         self._add_scalebars()
 
         # Check for OpenGL
-        # If a user doesn't specify whether or not to use it, disable it (performance
-        # differences seem minimal, and PyOpenGL is an optional requirement)
+        # If a user doesn't specify whether or not to use it, disable it (PyOpenGL is an
+        # optional requirement)
         opengl_key = "MNE_BROWSER_USE_OPENGL"
         if self.mne.use_opengl is None:  # default: opt-in
             config_val = get_config(opengl_key, "").lower()
@@ -472,9 +472,9 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
                 import OpenGL
             except (ModuleNotFoundError, ImportError):
                 warn(
-                    "PyOpenGL was not found and OpenGL cannot be used. "
-                    "Consider installing pyopengl with pip or conda or set "
-                    '"use_opengl=False" to avoid this warning.'
+                    "PyOpenGL was not found so OpenGL cannot be used. Consider "
+                    "installing PyOpenGL or setting 'use_opengl=False' to avoid this "
+                    "warning."
                 )
                 self.mne.use_opengl = False
             else:
@@ -487,10 +487,20 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
             and not check_version("pyqtgraph", "0.13.8")
         ):  # pragma: no cover
             warn(
-                "On macOS, Qt 6.10.0, pyqtgraph < 0.13.8, with use_opengl=True results "
-                f"in very slow performance. Consider downgrading {API_NAME}, "
-                "setting use_opengl=False (which can hurt performance), or "
-                "upgrading pyqtgraph once 0.13.8 is released"
+                "On macOS, the combination of Qt 6.10.0 and pyqtgraph < 0.13.8 with "
+                "'use_opengl=True' results in poor performance. Consider downgrading "
+                f"{API_NAME}, setting 'use_opengl=False' (which can hurt performance), "
+                "or upgrading pyqtgraph."
+            )
+        if (
+            platform.system() == "Linux"
+            and self.mne.antialiasing
+            and not self.mne.use_opengl
+        ):  # pragma: no cover
+            warn(
+                "On Linux, antialiasing without OpenGL can result in poor performance. "
+                "Consider installing PyOpenGL or disabling antialiasing in the browser "
+                "settings (or by pressing 'l')."
             )
         # Initialize BrowserView (inherits QGraphicsView)
         self.mne.view = BrowserView(

--- a/src/mne_qt_browser/_pg_figure.py
+++ b/src/mne_qt_browser/_pg_figure.py
@@ -499,8 +499,8 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):  # type: i
         ):  # pragma: no cover
             warn(
                 "On Linux, antialiasing without OpenGL can result in poor performance. "
-                "Consider installing PyOpenGL or disabling antialiasing in the browser "
-                "settings (or by pressing 'l')."
+                "Consider installing PyOpenGL and setting 'use_opengl=True' or "
+                "disabling antialiasing in the browser settings (or by pressing 'l')."
             )
         # Initialize BrowserView (inherits QGraphicsView)
         self.mne.view = BrowserView(

--- a/src/mne_qt_browser/_pg_figure.py
+++ b/src/mne_qt_browser/_pg_figure.py
@@ -500,7 +500,10 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):  # type: i
             warn(
                 "On Linux, antialiasing without OpenGL can result in poor performance. "
                 "Consider installing PyOpenGL and setting 'use_opengl=True' or "
-                "disabling antialiasing in the browser settings (or by pressing 'l')."
+                "disabling antialiasing in the browser settings (or by pressing 'l'). "
+                "Note that on Wayland, even with OpenGL enabled, performance may still "
+                "be significantly lower than on X11. As a workaround, set "
+                "'QT_QPA_PLATFORM=xcb' to use XWayland (X11 compatibility layer)."
             )
         # Initialize BrowserView (inherits QGraphicsView)
         self.mne.view = BrowserView(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 # Copyright the MNE Qt Browser contributors.
 
 import os
+import platform
 from pathlib import Path
 
 import mne
@@ -13,6 +14,14 @@ _store = {"Raw": {}, "Epochs_unicolor": {}, "Epochs_multicolor": {}}
 
 def pytest_configure(config):
     """Configure pytest options."""
+    # Enable OpenGL on Linux
+    if platform.system() == "Linux" and "MNE_BROWSER_USE_OPENGL" not in os.environ:
+        try:
+            import OpenGL  # noqa: F401
+
+            os.environ["MNE_BROWSER_USE_OPENGL"] = "true"
+        except ImportError:
+            pass
     # Markers
     for marker in ("benchmark", "pgtest", "slowtest"):
         config.addinivalue_line("markers", marker)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,14 +14,6 @@ _store = {"Raw": {}, "Epochs_unicolor": {}, "Epochs_multicolor": {}}
 
 def pytest_configure(config):
     """Configure pytest options."""
-    # Enable OpenGL on Linux
-    if platform.system() == "Linux" and "MNE_BROWSER_USE_OPENGL" not in os.environ:
-        try:
-            import OpenGL  # noqa: F401
-
-            os.environ["MNE_BROWSER_USE_OPENGL"] = "true"
-        except ImportError:
-            pass
     # Markers
     for marker in ("benchmark", "pgtest", "slowtest"):
         config.addinivalue_line("markers", marker)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@
 # Copyright the MNE Qt Browser contributors.
 
 import os
-import platform
 from pathlib import Path
 
 import mne


### PR DESCRIPTION
Performance on Linux without OpenGL is extremely poor. In contrast to what I mentioned in #355, installing PyOpenGL actually improves performance a lot, so I think we should at least show an appropriate warning. I've also removed PyOpenGL as a requirement on macOS, since this package has no effect on that platform. So I would say this fixes #355.

Example:

```python
import mne
from mne.datasets import sample

mne.viz.set_browser_backend("qt")

raw = mne.io.read_raw_fif(
    sample.data_path() / "MEG" / "sample" / "sample_audvis_raw.fif"
)
raw.plot(splash=False)
```

The last line needs to be changed as follows to achieve a decent performance:

```
raw.plot(splash=False, use_opengl=True)
```

Note that it would be kind of nice to expose an `antialiasing` parameter (similar to `use_opengl`), but for that we'd have to change `BaseRaw.plot` first.

Closes #375