### PR TITLE
FIX: MNE_BROWSER_PRECOMPUTE=true epoch rejection creating solid blocks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -156,9 +156,9 @@ jobs:
           # https://wiki.qt.io/Qt_for_Python_Development_Notes#1._Juni_2023
           if [[ "$QT_LIB" == "PySide6" ]]; then
             if [[ "$RUNNER_OS" == "macOS" ]]; then
-              QT_LIB_INSTALL="PySide6!=6.5.1,!=6.7.0,!=6.7.1,!=6.8.0,!=6.8.0.1,!=6.9.1,!=6.10.0"
+              QT_LIB_INSTALL="PySide6!=6.5.1,!=6.7.0,!=6.7.1,!=6.8.0,!=6.8.0.1,!=6.9.1,!=6.10.0,!=6.11.1"
             else
-              QT_LIB_INSTALL="PySide6!=6.5.1,!=6.7.0,!=6.7.1,!=6.8.0,!=6.8.0.1,!=6.9.1"
+              QT_LIB_INSTALL="PySide6!=6.5.1,!=6.7.0,!=6.7.1,!=6.8.0,!=6.8.0.1,!=6.9.1,!=6.11.1"
             fi
           else
             QT_LIB_INSTALL="$QT_LIB"

--- a/src/mne_qt_browser/_graphic_items.py
+++ b/src/mne_qt_browser/_graphic_items.py
@@ -527,7 +527,9 @@ class DataTrace(PlotCurveItem):
     def update_scale(self):  # noqa: D102
         transform = QTransform()
         if self.mne.data_precomputed:
-            transform.scale(1.0, self.mne.scale_factor / self.mne.scalings[self.ch_type])
+            transform.scale(
+                1.0, self.mne.scale_factor / self.mne.scalings[self.ch_type]
+            )
         else:
             transform.scale(1.0, self.mne.scale_factor)
         self.setTransform(transform)
@@ -566,7 +568,9 @@ class DataTrace(PlotCurveItem):
 
         transform = QTransform()
         if self.mne.data_precomputed:
-            transform.scale(1.0, self.mne.scale_factor / self.mne.scalings[self.ch_type])
+            transform.scale(
+                1.0, self.mne.scale_factor / self.mne.scalings[self.ch_type]
+            )
             data = self.mne.data[self.order_idx]
         else:
             transform.scale(1.0, self.mne.scale_factor)

--- a/src/mne_qt_browser/_graphic_items.py
+++ b/src/mne_qt_browser/_graphic_items.py
@@ -526,7 +526,10 @@ class DataTrace(PlotCurveItem):
     @propagate_to_children
     def update_scale(self):  # noqa: D102
         transform = QTransform()
-        transform.scale(1.0, self.mne.scale_factor)
+        if self.mne.data_precomputed:
+            transform.scale(1.0, self.mne.scale_factor / self.mne.scalings[self.ch_type])
+        else:
+            transform.scale(1.0, self.mne.scale_factor)
         self.setTransform(transform)
 
         if self.mne.clipping is not None:
@@ -561,11 +564,14 @@ class DataTrace(PlotCurveItem):
             connect = "all"
             skip = True
 
+        transform = QTransform()
         if self.mne.data_precomputed:
+            transform.scale(1.0, self.mne.scale_factor / self.mne.scalings[self.ch_type])
             data = self.mne.data[self.order_idx]
-            data /= self.mne.scalings[self.ch_type]
         else:
+            transform.scale(1.0, self.mne.scale_factor)
             data = self.mne.data[self.range_idx]
+        self.setTransform(transform)
         times = self.mne.times
 
         # Get decim-specific time if enabled

--- a/src/mne_qt_browser/_graphic_items.py
+++ b/src/mne_qt_browser/_graphic_items.py
@@ -523,8 +523,7 @@ class DataTrace(PlotCurveItem):
         else:
             self.ypos = self.range_idx + self.mne.ch_start + 1
 
-    @propagate_to_children
-    def update_scale(self):  # noqa: D102
+    def _apply_transform(self):
         transform = QTransform()
         if self.mne.data_precomputed:
             transform.scale(
@@ -533,6 +532,10 @@ class DataTrace(PlotCurveItem):
         else:
             transform.scale(1.0, self.mne.scale_factor)
         self.setTransform(transform)
+
+    @propagate_to_children
+    def update_scale(self):  # noqa: D102
+        self._apply_transform()
 
         if self.mne.clipping is not None:
             self.update_data(propagate=False)
@@ -566,16 +569,11 @@ class DataTrace(PlotCurveItem):
             connect = "all"
             skip = True
 
-        transform = QTransform()
+        self._apply_transform()
         if self.mne.data_precomputed:
-            transform.scale(
-                1.0, self.mne.scale_factor / self.mne.scalings[self.ch_type]
-            )
             data = self.mne.data[self.order_idx]
         else:
-            transform.scale(1.0, self.mne.scale_factor)
             data = self.mne.data[self.range_idx]
-        self.setTransform(transform)
         times = self.mne.times
 
         # Get decim-specific time if enabled

--- a/src/mne_qt_browser/_graphic_items.py
+++ b/src/mne_qt_browser/_graphic_items.py
@@ -438,11 +438,11 @@ class DataTrace(PlotCurveItem):
         # set attributes
         self.set_ch_idx(ch_idx)
         self.update_color()
-        self.update_scale()
-        # Avoid calling self.update_data() twice on initialization because of
-        # update_scale()
+
         if self.mne.clipping is None:
             self.update_data()
+        else:
+            self.update_scale()
 
         # Add to main plot
         self.mne.plt.addItem(self)

--- a/src/mne_qt_browser/_pg_figure.py
+++ b/src/mne_qt_browser/_pg_figure.py
@@ -1418,6 +1418,8 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):  # type: i
         if self._rerun_load_thread:
             self._rerun_load_thread = False
             self._init_precompute()
+        else:
+            self._redraw()
 
     def _init_precompute(self):
         # Remove previously loaded data


### PR DESCRIPTION
When clicking an epoch to mark/unmark it as bad while precompute is enabled, the epoch column turns into a solid colored block instead of showing the waveform highlighted. The included epochs also appear as solid blue. Scrolling away and back with the arrow keys temporarily restores included epochs but the rejected epoch remains a solid red bar.

There also seemed to be issues when changing the colours on the different channels such as in the first mentioned issue below.


#### Reference issue

- https://github.com/mne-tools/mne-qt-browser/issues/408
  - Note that I just looked at the qt backend and did not check the matplotlib backend
- https://github.com/mne-tools/mne-qt-browser/issues/270

#### What does this implement/fix?

The fix is based in the `update_data()` function where the previous version would directly divide the data itself in place through a numpy view. The fix moves the scaling out of the data entirely and into the Qt transform.

For the epoch fix, I also had to add a redraw at the end of `_precompute_finished()`. Epoch rejection calls `update_data()` directly without going through `_update_data()` first, so without the explicit redraw, `self.mne.data` was never transitioned to the precomputed buffer before epoch rejection tried to use it.

#### Additional information

I have tried the fix on MacOS and Linux systems. Let me know if I should change anything else and please do let me know if this works for you too.

Image of it working on epochs :-)

<img width="972" height="673" alt="image" src="https://github.com/user-attachments/assets/82381b74-86d3-4446-9cf0-c87d62f864de" />
