### PR TITLE
MAINT: Remove PyQt5 from testing matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   package:
     runs-on: ubuntu-latest
+    if: github.event_name == 'release'
     permissions:
       id-token: write
     environment:
@@ -26,8 +27,6 @@ jobs:
       - uses: actions/checkout@v6
       - name: Set up Python
         uses: actions/setup-python@v6
-        with:
-          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -38,4 +37,3 @@ jobs:
         run: twine check --strict dist/*
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        if: github.event_name == 'release'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, windows, macos]
-        mne: [main, maint/1.7]
+        mne: [main, maint/1.12]
         opengl: ['opengl']
         python: ['3.12']
         name: [matrix]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,8 +113,8 @@ jobs:
         os: [ubuntu]
         mne: [main]
         opengl: [opengl]
-        qt: [PyQt5, PyQt6, PySide6]
-        python: ['3.10']  # When going to 3.11, PySide2 should be removed or special-cased
+        qt: [PyQt6, PySide6]
+        python: ['3.14']
         name: [matrix]
         include:
           - os: macos
@@ -196,7 +196,6 @@ jobs:
       # case given our primary target moving forward is Qt6+
       - run: pytest tests/test_speed.py --cov-report=xml --cov-append
         name: Run benchmarks
-        if: runner.os != 'Linux' || matrix.qt != 'PyQt5'
       - uses: codecov/codecov-action@v7
         if: always()
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
             python: '3.12'
             name: no opengl
           - os: ubuntu
-            mne: maint/1.5
+            mne: maint/1.7  # 2 years back as of 2026/06/23
             opengl: 'opengl'
             python: '3.10'
             name: old
@@ -74,9 +74,7 @@ jobs:
           python -m pip install -ve .${PIP_OPTION} "PyQt6!=6.6.1" "PyQt6-Qt6!=6.6.1,!=6.6.2,!=6.6.3"
           if [[ "${{ matrix.pip }}" == "pre" ]]; then
             echo "Upgrading to pre-release NumPy, SciPy, matplotlib, and pyqtgraph"
-            # No SciPy until https://github.com/scikit-learn/scikit-learn/issues/33616
-            # "scipy>=1.14.0.dev0"
-            python -m pip install --upgrade --pre --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0.dev0" "matplotlib>=3.9.0.dev0" "scikit-learn>=1.5.dev0" "git+https://github.com/pyqtgraph/pyqtgraph.git"
+            python -m pip install --upgrade --pre --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.6.0.dev0" "scipy>=1.19.0.dev0" "matplotlib>=3.12.0.dev0" "scikit-learn>=1.10.dev0" "git+https://github.com/pyqtgraph/pyqtgraph.git"
           fi
       - run: ./tools/get_testing_version.sh
         working-directory: ../mne-python


### PR DESCRIPTION
Inspired by a spurious segfault in https://github.com/mne-tools/mne-qt-browser/pull/419 -- latest PyQt5 release was almost 2 years ago and it's no longer being updated. We might as well drop it from the testing matrix. In theory it should continue to work but I don't think we need to fight with it in CIs, etc.