### PR TITLE
FIX: Checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,13 +65,18 @@ jobs:
           set -eo pipefail
           python -m pip install --upgrade pip
           git clone -b ${MNE_BRANCH} --single-branch --branch main https://github.com/mne-tools/mne-python.git ../mne-python
-          python -m pip install -qe ../mne-python
+          pushd ../mne-python
+          if [[ "${{ matrix.mne }}" == "main" ]]; then
+            GROUP_EXTRA="--group test"
+          fi
+          python -m pip install -qe . $GROUP_EXTRA
+          popd
           if [[ "${{ matrix.opengl }}" == "opengl" ]]; then
             PIP_OPTION="[opengl,tests]"
           else
             PIP_OPTION="[tests]"
           fi
-          python -m pip install -ve .${PIP_OPTION} "PyQt6!=6.6.1" "PyQt6-Qt6!=6.6.1,!=6.6.2,!=6.6.3"
+          python -m pip install -ve .${PIP_OPTION} PySide6
           if [[ "${{ matrix.pip }}" == "pre" ]]; then
             echo "Upgrading to pre-release NumPy, SciPy, matplotlib, and pyqtgraph"
             python -m pip install --upgrade --pre --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.6.0.dev0" "scipy>=1.19.0.dev0" "matplotlib>=3.12.0.dev0" "scikit-learn>=1.10.dev0" "git+https://github.com/pyqtgraph/pyqtgraph.git"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -149,7 +149,9 @@ jobs:
           set -eo pipefail
           python -m pip install --upgrade pip
           git clone -b ${MNE_BRANCH} --single-branch --branch main https://github.com/mne-tools/mne-python.git ../mne-python
-          python -m pip install -qe ../mne-python --group test
+          pushd ../mne-python
+          python -m pip install -qe . --group test
+          popd
           if [[ "${{ matrix.opengl }}" == "opengl" ]]; then
             PIP_OPTION="[opengl,tests]"
           else

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -149,25 +149,14 @@ jobs:
           set -eo pipefail
           python -m pip install --upgrade pip
           git clone -b ${MNE_BRANCH} --single-branch --branch main https://github.com/mne-tools/mne-python.git ../mne-python
-          python -m pip install -qe ../mne-python
-          # Avoid a problematic versions of PySide6
-          # https://wiki.qt.io/Qt_for_Python_Development_Notes#1._Juni_2023
-          if [[ "$QT_LIB" == "PySide6" ]]; then
-            if [[ "$RUNNER_OS" == "macOS" ]]; then
-              QT_LIB_INSTALL="PySide6!=6.5.1,!=6.7.0,!=6.7.1,!=6.8.0,!=6.8.0.1,!=6.9.1,!=6.10.0"
-            else
-              QT_LIB_INSTALL="PySide6!=6.5.1,!=6.7.0,!=6.7.1,!=6.8.0,!=6.8.0.1,!=6.9.1"
-            fi
-          else
-            QT_LIB_INSTALL="$QT_LIB"
-          fi
+          python -m pip install -qe ../mne-python --group test
           if [[ "${{ matrix.opengl }}" == "opengl" ]]; then
             PIP_OPTION="[opengl,tests]"
           else
             PIP_OPTION="[tests]"
           fi
           set -x
-          python -m pip install -ve .${PIP_OPTION} ${QT_LIB_INSTALL}
+          python -m pip install -ve .${PIP_OPTION} ${QT_LIB}
       - run: bash ./tools/get_testing_version.sh
         working-directory: ../mne-python
       - uses: actions/cache@v6

--- a/src/mne_qt_browser/_pg_figure.py
+++ b/src/mne_qt_browser/_pg_figure.py
@@ -1458,8 +1458,9 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):  # type: i
     def _init_precompute(self):
         # Remove previously loaded data
         self.mne.data_precomputed = False
-        if all([hasattr(self.mne, st) for st in ["global_data", "global_times"]]):
-            del self.mne.global_data, self.mne.global_times
+        for st in ["global_data", "global_times"]:
+            if hasattr(self.mne, st):
+                delattr(self.mne, st)
         gc.collect()
 
         if self.mne.precompute == "auto":

--- a/src/mne_qt_browser/_pg_figure.py
+++ b/src/mne_qt_browser/_pg_figure.py
@@ -1458,9 +1458,8 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):  # type: i
     def _init_precompute(self):
         # Remove previously loaded data
         self.mne.data_precomputed = False
-        for st in ["global_data", "global_times"]:
-            if hasattr(self.mne, st):
-                delattr(self.mne, st)
+        if all([hasattr(self.mne, st) for st in ["global_data", "global_times"]]):
+            del self.mne.global_data, self.mne.global_times
         gc.collect()
 
         if self.mne.precompute == "auto":

--- a/src/mne_qt_browser/_utils.py
+++ b/src/mne_qt_browser/_utils.py
@@ -29,7 +29,7 @@ _unit_per_inch = dict(mm=25.4, cm=2.54, inch=1.0)
 
 def _disconnect(sig, *, allow_error=False):
     try:
-        with warnings.catch_warnings():
+        with warnings.catch_warnings(record=True):
             warnings.filterwarnings(
                 "ignore", "Failed to disconnect", category=RuntimeWarning
             )


### PR DESCRIPTION
On Pyside6 6.11.1 I sometimes get when closing windows:
```
/home/larsoner/python/mne-qt-browser/src/mne_qt_browser/_utils.py:36: RuntimeWarning: libpyside: Failed to disconnect (None) from signal "triggered()".
  sig.disconnect()
/home/larsoner/python/mne-qt-browser/src/mne_qt_browser/_utils.py:36: RuntimeWarning: libpyside: Failed to disconnect (None) from signal "triggered()".
  sig.disconnect()
/home/larsoner/python/mne-qt-browser/src/mne_qt_browser/_utils.py:36: RuntimeWarning: libpyside: Failed to disconnect (None) from signal "triggered()".
  sig.disconnect()
/home/larsoner/python/mne-qt-browser/src/mne_qt_browser/_utils.py:36: RuntimeWarning: libpyside: Failed to disconnect (None) from signal "triggered()".
  sig.disconnect()
/home/larsoner/python/mne-qt-browser/src/mne_qt_browser/_utils.py:36: RuntimeWarning: libpyside: Failed to disconnect (None) from signal "triggered()".
  sig.disconnect()
```
This helps swallow those. I also intermittently got some `AttributeError`s so this safeguards a `delattr`