### PR TITLE
Fix suppression of prefixed PySide disconnect warnings

### DIFF
--- a/src/mne_qt_browser/_utils.py
+++ b/src/mne_qt_browser/_utils.py
@@ -31,7 +31,9 @@ def _disconnect(sig, *, allow_error=False):
     try:
         with warnings.catch_warnings():
             warnings.filterwarnings(
-                "ignore", "Failed to disconnect", category=RuntimeWarning
+                "ignore",
+                "(?:libpyside: )?Failed to disconnect",
+                category=RuntimeWarning,
             )
             sig.disconnect()
     except (TypeError, RuntimeError, SystemError):  # if are no connections, ignore

--- a/tests/test_pg_specific.py
+++ b/tests/test_pg_specific.py
@@ -1,6 +1,8 @@
 # License: BSD-3-Clause
 # Copyright the MNE Qt Browser contributors.
 
+import warnings
+
 import numpy as np
 import pytest
 from mne import Annotations
@@ -10,6 +12,7 @@ from qtpy.QtCore import Qt
 from qtpy.QtTest import QTest
 
 from mne_qt_browser._colors import _lab_to_rgb, _rgb_to_lab
+from mne_qt_browser._utils import _disconnect
 
 LESS_TIME = "Show fewer time points"
 MORE_TIME = "Show more time points"
@@ -19,6 +22,26 @@ REDUCE_AMPLITUDE = "Reduce amplitude"
 INCREASE_AMPLITUDE = "Increase amplitude"
 TOGGLE_ANNOTATIONS = "Toggle annotations mode"
 SHOW_PROJECTORS = "Show projectors"
+
+
+def test_disconnect_warning_filter():
+    """Test that only known PySide disconnect warnings are suppressed."""
+
+    class Signal:
+        def __init__(self, message):
+            self.message = message
+
+        def disconnect(self):
+            warnings.warn(self.message, RuntimeWarning)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _disconnect(
+            Signal('libpyside: Failed to disconnect (None) from signal "triggered()".')
+        )
+
+    with pytest.warns(RuntimeWarning, match="unrelated warning"):
+        _disconnect(Signal("unrelated warning"))
 
 
 def test_annotations_single_sample(raw_orig, pg_backend):


### PR DESCRIPTION
#### Reference issue

N/A

#### What does this implement/fix?

PySide now prefixes its no-connections warning with `libpyside:`, so the existing `warnings.filterwarnings` message pattern no longer matches it. Closing the browser consequently emits repeated `RuntimeWarning: libpyside: Failed to disconnect ...` messages.

This updates `_disconnect` to accept the optional `libpyside: ` prefix while retaining the original message match. A regression test covers the prefixed warning and verifies that unrelated runtime warnings are not suppressed.

#### Additional information

Validated with:

- `pytest -q -o addopts='' tests/test_pg_specific.py::test_disconnect_warning_filter`
- `ruff check src/mne_qt_browser/_utils.py tests/test_pg_specific.py`
- `ruff format --check src/mne_qt_browser/_utils.py tests/test_pg_specific.py`
- An end-to-end `Raw.plot()` Qt-browser close using PySide6 6.11.1, which emitted no disconnect runtime warnings after the change.
