### PR TITLE
Fix CIs and simplify

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           fetch-depth: 0
           repository: mne-tools/mne-python
-          workspace: ../mne-python          
+          workspace: ../mne-python
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,8 +62,7 @@ jobs:
         name: Install MNE-Python
         working-directory: mne-python
       - name: Install
-        run: python -m pip install -ve .${PIP_OPTION} ${QT_LIB}
-          python -m pip install -ve .${PIP_OPTION} ${{ matrix.qt }}\
+        run: python -m pip install -ve .[tests] ${{ matrix.qt }}
       - name: Install pip-pre deps
         run: python -m pip install --upgrade --pre --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.6.0.dev0" "scipy>=1.19.0.dev0" "matplotlib>=3.12.0.dev0" "git+https://github.com/pyqtgraph/pyqtgraph.git"
         if: matrix.name == 'pip-pre'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,40 +16,29 @@ jobs:
       matrix:
         os: [ubuntu, windows, macos]
         mne: [main, maint/1.12]
-        opengl: ['opengl']
-        python: ['3.12']
-        name: [matrix]
-        pip: ['']
+        python: ['3.14']
+        qt: [PySide6]
+        name: [PySide6]
         include:
           - os: ubuntu
             mne: main
-            opengl: ''
-            python: '3.12'
-            name: no opengl
-          - os: ubuntu
-            mne: maint/1.7
-            opengl: ''
-            python: '3.12'
-            name: no opengl
+            python: '3.11'
+            qt: PyQt6
+            name: PyQt6
           - os: ubuntu
             mne: maint/1.7  # 2 years back as of 2026/06/23
-            opengl: 'opengl'
             python: '3.10'
+            qt: PySide6
             name: old
           - os: ubuntu
             mne: main
-            opengl: 'opengl'
-            python: '3.12'
-            pip: pre
+            python: '3.14'
             name: pip-pre
     name: pytest ${{ matrix.name }} / ${{ matrix.os }} / MNE ${{ matrix.mne }}
     runs-on: ${{ matrix.os }}-latest
     env:
       MNE_LOGGING_LEVEL: 'warning'
-      MKL_NUM_THREADS: '1'
-      PYTHONUNBUFFERED: '1'
-      MNE_BRANCH: ${{ matrix.mne }}
-      PYTHON_VERSION: ${{ matrix.python }}
+      OMP_NUM_THREADS: '1'
     defaults:
       run:
         shell: bash
@@ -57,25 +46,27 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          repository: mne-tools/mne-python
+          workspace: ../mne-python          
       - uses: actions/setup-python@v6
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - name: Install dependencies
-        run: |  # use MNE main to ensure test files are available
-          set -eo pipefail
+          python-version: ${{ matrix.python }}
+      - run: |
+          set -x
           python -m pip install --upgrade pip
-          git clone -b ${MNE_BRANCH} --single-branch --branch main https://github.com/mne-tools/mne-python.git ../mne-python
-          python -m pip install -qe ../mne-python
-          if [[ "${{ matrix.opengl }}" == "opengl" ]]; then
-            PIP_OPTION="[opengl,tests]"
-          else
-            PIP_OPTION="[tests]"
-          fi
-          python -m pip install -ve .${PIP_OPTION} "PyQt6!=6.6.1" "PyQt6-Qt6!=6.6.1,!=6.6.2,!=6.6.3"
-          if [[ "${{ matrix.pip }}" == "pre" ]]; then
-            echo "Upgrading to pre-release NumPy, SciPy, matplotlib, and pyqtgraph"
-            python -m pip install --upgrade --pre --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.6.0.dev0" "scipy>=1.19.0.dev0" "matplotlib>=3.12.0.dev0" "git+https://github.com/pyqtgraph/pyqtgraph.git"
-          fi
+          git checkout -b "${{ matrix.mne }}" origin/"${{ matrix.mne }}"
+          python -m pip install -e .
+        name: Install MNE-Python
+        working-directory: ../mne-python
+      - name: Install
+        run: python -m pip install -ve .${PIP_OPTION} ${QT_LIB}
+          python -m pip install -ve .${PIP_OPTION} ${{ matrix.qt }}\
+      - name: Install pip-pre deps
+        run: python -m pip install --upgrade --pre --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.6.0.dev0" "scipy>=1.19.0.dev0" "matplotlib>=3.12.0.dev0" "git+https://github.com/pyqtgraph/pyqtgraph.git"
+        if: matrix.name == 'pip-pre'
       - run: ./tools/get_testing_version.sh
         working-directory: ../mne-python
       - uses: actions/cache@v6
@@ -87,10 +78,6 @@ jobs:
       - uses: pyvista/setup-headless-display-action@main
         with:
           qt: true
-      - run: glxinfo | grep enderer
-        name: Check OpenGL
-        working-directory: ../mne-python
-        if: runner.os == 'Linux' && contains(matrix.opengl, 'opengl')
       - run: mne sys_info
       - run: pytest -m pgtest --cov=mne_qt_browser --cov-report=xml ../mne-python/mne/report ../mne-python/mne/viz
         name: Run MNE-Tests
@@ -100,100 +87,6 @@ jobs:
       - run: pytest tests/test_speed.py --cov-report=xml --cov-append
         name: Run benchmarks
         if: runner.os != 'macOS'
-      - uses: codecov/codecov-action@v7
-        if: always()
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-  qt:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu]
-        mne: [main]
-        opengl: [opengl]
-        qt: [PyQt6, PySide6]
-        python: ['3.14']
-        name: [matrix]
-        include:
-          - os: macos
-            mne: main
-            opengl: 'opengl'
-            qt: PySide6
-            python: '3.11'
-          - os: windows
-            mne: main
-            opengl: 'opengl'
-            qt: PySide6
-            python: '3.11'
-    name: ${{ matrix.qt }} / ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}-latest
-    env:
-      MNE_LOGGING_LEVEL: 'warning'
-      MKL_NUM_THREADS: '1'
-      PYTHONUNBUFFERED: '1'
-      MNE_BRANCH: ${{ matrix.mne }}
-      PYTHON_VERSION: ${{ matrix.python }}
-      QT_LIB: ${{ matrix.qt }}
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - name: Install dependencies
-        run: |  # use MNE main to ensure test files are available
-          set -eo pipefail
-          python -m pip install --upgrade pip
-          git clone -b ${MNE_BRANCH} --single-branch --branch main https://github.com/mne-tools/mne-python.git ../mne-python
-          python -m pip install -qe ../mne-python
-          # Avoid a problematic versions of PySide6
-          # https://wiki.qt.io/Qt_for_Python_Development_Notes#1._Juni_2023
-          if [[ "$QT_LIB" == "PySide6" ]]; then
-            if [[ "$RUNNER_OS" == "macOS" ]]; then
-              QT_LIB_INSTALL="PySide6!=6.5.1,!=6.7.0,!=6.7.1,!=6.8.0,!=6.8.0.1,!=6.9.1,!=6.10.0"
-            else
-              QT_LIB_INSTALL="PySide6!=6.5.1,!=6.7.0,!=6.7.1,!=6.8.0,!=6.8.0.1,!=6.9.1"
-            fi
-          else
-            QT_LIB_INSTALL="$QT_LIB"
-          fi
-          if [[ "${{ matrix.opengl }}" == "opengl" ]]; then
-            PIP_OPTION="[opengl,tests]"
-          else
-            PIP_OPTION="[tests]"
-          fi
-          set -x
-          python -m pip install -ve .${PIP_OPTION} ${QT_LIB_INSTALL}
-      - run: bash ./tools/get_testing_version.sh
-        working-directory: ../mne-python
-      - uses: actions/cache@v6
-        with:
-          key: ${{ env.TESTING_VERSION }}
-          path: ~/mne_data
-      - run: python -c 'import mne; print(mne.datasets.testing.data_path(verbose=True))'
-        name: 'Download testing data'
-      - uses: pyvista/setup-headless-display-action@main
-        with:
-          qt: true
-      - name: Start Qt on its own
-        run: LD_DEBUG=libs python -c "from ${QT_LIB}.QtWidgets import QApplication, QWidget; app = QApplication([]); import matplotlib; matplotlib.use('QtAgg'); import matplotlib.pyplot as plt; plt.figure()"
-      - name: Check Qt
-        run: |
-          mne sys_info -pd
-          echo ${QT_LIB}:
-          mne sys_info -pd | grep "^.*qtpy.*${QT_LIB}=.*$"
-      - run: pytest -m pgtest --cov=mne_qt_browser --cov-report=xml ../mne-python/mne/report ../mne-python/mne/viz
-        name: Run MNE-Tests
-      - run: pytest --error-for-skips tests/test_pg_specific.py --cov-report=xml --cov-append
-        name: Run pyqtgraph-specific tests
-      # For some reason this dies on Linux PySide2. We can live without this
-      # case given our primary target moving forward is Qt6+
-      - run: pytest tests/test_speed.py --cov-report=xml --cov-append
-        name: Run benchmarks
       - uses: codecov/codecov-action@v7
         if: always()
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,13 +51,13 @@ jobs:
           fetch-depth: 0
           repository: mne-tools/mne-python
           path: mne-python
+          ref: ${{ matrix.mne }}
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
       - run: |
-          set -x
           python -m pip install --upgrade pip
-          git checkout -b "${{ matrix.mne }}" origin/"${{ matrix.mne }}"
+          test "$(git branch --show-curent)" == "${{ matrix.mne }}"
           python -m pip install -e .
         name: Install MNE-Python
         working-directory: mne-python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
           python-version: ${{ matrix.python }}
       - run: |
           python -m pip install --upgrade pip
-          test "$(git branch --show-curent)" == "${{ matrix.mne }}"
+          test "$(git branch --show-current)" == "${{ matrix.mne }}"
           python -m pip install -e .
         name: Install MNE-Python
         working-directory: mne-python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           fetch-depth: 0
           repository: mne-tools/mne-python
-          path: ../mne-python
+          path: mne-python
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
@@ -60,7 +60,7 @@ jobs:
           git checkout -b "${{ matrix.mne }}" origin/"${{ matrix.mne }}"
           python -m pip install -e .
         name: Install MNE-Python
-        working-directory: ../mne-python
+        working-directory: mne-python
       - name: Install
         run: python -m pip install -ve .${PIP_OPTION} ${QT_LIB}
           python -m pip install -ve .${PIP_OPTION} ${{ matrix.qt }}\
@@ -68,7 +68,7 @@ jobs:
         run: python -m pip install --upgrade --pre --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.6.0.dev0" "scipy>=1.19.0.dev0" "matplotlib>=3.12.0.dev0" "git+https://github.com/pyqtgraph/pyqtgraph.git"
         if: matrix.name == 'pip-pre'
       - run: ./tools/get_testing_version.sh
-        working-directory: ../mne-python
+        working-directory: mne-python
       - uses: actions/cache@v6
         with:
           key: ${{ env.TESTING_VERSION }}
@@ -79,7 +79,7 @@ jobs:
         with:
           qt: true
       - run: mne sys_info
-      - run: pytest -m pgtest --cov=mne_qt_browser --cov-report=xml ../mne-python/mne/report ../mne-python/mne/viz
+      - run: pytest -m pgtest --cov=mne_qt_browser --cov-report=xml mne-python/mne/report mne-python/mne/viz
         name: Run MNE-Tests
       - run: pytest --error-for-skips tests/test_pg_specific.py --cov-report=xml --cov-append
         name: Run pyqtgraph-specific tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,6 @@ jobs:
         os: [ubuntu, windows, macos]
         mne: [main, maint/1.12]
         python: ['3.14']
-        qt: [PySide6]
         name: [PySide6]
         include:
           - os: ubuntu
@@ -28,7 +27,6 @@ jobs:
           - os: ubuntu
             mne: maint/1.7  # 2 years back as of 2026/06/23
             python: '3.10'
-            qt: PySide6
             name: old
           - os: ubuntu
             mne: main
@@ -62,7 +60,7 @@ jobs:
         name: Install MNE-Python
         working-directory: mne-python
       - name: Install
-        run: python -m pip install -ve .[tests] ${{ matrix.qt }}
+        run: python -m pip install -ve .[tests] "${{ matrix.qt || 'PySide6' }}"
       - name: Install pip-pre deps
         run: python -m pip install --upgrade --pre --only-binary ":all:" --default-timeout=60 --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.6.0.dev0" "scipy>=1.19.0.dev0" "matplotlib>=3.12.0.dev0" "git+https://github.com/pyqtgraph/pyqtgraph.git"
         if: matrix.name == 'pip-pre'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
             qt: PyQt6
             name: PyQt6
           - os: ubuntu
-            mne: maint/1.8  # released 2024/08/18
+            mne: maint/1.7  # released 2024/04/19
             python: '3.10'
             name: old
           - os: ubuntu

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
             qt: PyQt6
             name: PyQt6
           - os: ubuntu
-            mne: maint/1.7  # 2 years back as of 2026/06/23
+            mne: maint/1.8  # released 2024/08/18
             python: '3.10'
             name: old
           - os: ubuntu

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           fetch-depth: 0
           repository: mne-tools/mne-python
-          workspace: ../mne-python
+          path: ..
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
             qt: PyQt6
             name: PyQt6
           - os: ubuntu
-            mne: maint/1.7  # released 2024/04/19
+            mne: maint/1.8  # released 2024/08/18
             python: '3.10'
             name: old
           - os: ubuntu

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           fetch-depth: 0
           repository: mne-tools/mne-python
-          path: ..
+          path: ../mne-python
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,10 +6,70 @@ from pathlib import Path
 
 import mne
 import pytest
-from mne.conftest import garbage_collect, pg_backend  # noqa: F401
+from mne.conftest import _check_pyqtgraph
+from mne.viz._figure import use_browser_backend
+from pytest import StashKey
 from qtpy.QtCore import QSettings
+from refleak.testing import Snapshot, gc_collect_once
 
 _store = {"Raw": {}, "Epochs_unicolor": {}, "Epochs_multicolor": {}}
+
+# Stash each test's phase reports so fixtures can tell whether the test itself
+# passed (see https://docs.pytest.org/en/stable/how-to/fixtures.html
+# #using-markers-to-pass-data-to-fixtures).
+_phase_report_key = StashKey()
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    """Stash the status of each test phase."""
+    outcome = yield
+    rep = outcome.get_result()
+    item.stash.setdefault(_phase_report_key, {})[rep.when] = rep
+
+
+def _test_passed(request):
+    """Return whether the test body (the "call" phase) passed."""
+    if _phase_report_key not in request.node.stash:
+        return True
+    report = request.node.stash[_phase_report_key]
+    return "call" in report and report["call"].outcome == "passed"
+
+
+@pytest.fixture
+def garbage_collect(request):
+    """Garbage collect on exit."""
+    yield
+    gc_collect_once(request)
+
+
+@pytest.fixture
+def pg_backend(request, garbage_collect):
+    """Use for pyqtgraph-specific test-functions.
+
+    This overrides ``mne.conftest.pg_backend`` so that the leak check only runs
+    when the test itself passed. When a test fails, pytest keeps its traceback
+    (for reporting), which keeps that test's frame and hence its browser alive;
+    checking for leaked browsers then would blame the failing test (or cascade
+    into the next test using this fixture) for something the real failure caused.
+    """
+    _check_pyqtgraph(request)
+    from mne_qt_browser._pg_figure import MNEQtBrowser
+
+    with use_browser_backend("qt") as backend:
+        backend._close_all()
+        # Snapshot stores only ids, so it pins nothing alive; it lets us report
+        # only browsers that this test itself leaked.
+        snap = Snapshot(MNEQtBrowser, collect=False)
+        yield backend
+        backend._close_all()
+        # This shouldn't be necessary, but let's make sure nothing is stale
+        import mne_qt_browser
+
+        mne_qt_browser._browser_instances.clear()
+        if not _test_passed(request):
+            return
+        snap.assert_no_new(f"Closure of {request.node.name}", request=request)
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/test_pg_specific.py
+++ b/tests/test_pg_specific.py
@@ -215,7 +215,6 @@ def test_annotations_interactions(raw_orig, pg_backend):
 
 def test_ch_specific_annot(raw_orig, pg_backend):
     """Test plotting channel specific annotations."""
-    pytest.importorskip("mne", minversion="1.8")
     ch_names = ["MEG 0133", "MEG 0142", "MEG 0143", "MEG 0423"]
     annot_onset, annot_dur = 1, 2
     annots = Annotations([annot_onset], [annot_dur], "some_chs", ch_names=[ch_names])

--- a/tests/test_pg_specific.py
+++ b/tests/test_pg_specific.py
@@ -32,7 +32,8 @@ def test_annotations_single_sample(raw_orig, pg_backend):
     description = "A"
     first_time = raw_orig.first_time
     raw_orig.annotations.append(onset + first_time, duration, description)
-    fig = raw_orig.plot(duration=raw_orig.duration)
+    duration = raw_orig.n_times / raw_orig.info["sfreq"]
+    fig = raw_orig.plot(duration=duration)
     fig.test_mode = True
     # Activate annotation_mode
     fig._fake_keypress("a")
@@ -87,7 +88,8 @@ def test_annotations_recording_end(raw_orig, pg_backend):
     first_time = raw_orig.first_time
     raw_orig.annotations.append(onset + first_time, duration, description)
     n_anns = len(raw_orig.annotations)
-    fig = raw_orig.plot(duration=raw_orig.duration)
+    duration = raw_orig.n_times / raw_orig.info["sfreq"]
+    fig = raw_orig.plot(duration=duration)
     fig.test_mode = True
     # Activate annotation_mode
     fig._fake_keypress("a")

--- a/tests/test_pg_specific.py
+++ b/tests/test_pg_specific.py
@@ -215,6 +215,7 @@ def test_annotations_interactions(raw_orig, pg_backend):
 
 def test_ch_specific_annot(raw_orig, pg_backend):
     """Test plotting channel specific annotations."""
+    pytest.importorskip("mne", minversion="1.8")
     ch_names = ["MEG 0133", "MEG 0142", "MEG 0143", "MEG 0423"]
     annot_onset, annot_dur = 1, 2
     annots = Annotations([annot_onset], [annot_dur], "some_chs", ch_names=[ch_names])


### PR DESCRIPTION
We don't need to triage `opengl` installs anymore since PyQtGraph doesn't use `pyopengl`. Simplify CIs. Deduplicate blocks. Fix `maint/*` branch (it wasn't using it!).