### PR TITLE
MAINT: Isolate MNE config and shared fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,4 @@ dmypy.json
 junit-results.xml
 .vscode/
 .DS_Store
+/.claude

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,22 @@ _store = {"Raw": {}, "Epochs_unicolor": {}, "Epochs_multicolor": {}}
 
 
 @pytest.fixture(autouse=True, scope="session")
+def _isolated_mne_config(tmp_path_factory):
+    """Isolate the MNE config file for the test session.
+
+    Closing a browser writes e.g. MNE_BROWSE_RAW_SIZE via mne.set_config, which
+    would otherwise both trash the user's real config and make test behavior
+    depend on whatever earlier runs left there (window sizes change pixel->data
+    rounding in interaction tests).
+    """
+    config_dir = tmp_path_factory.mktemp("mne_config")
+    mp = pytest.MonkeyPatch()
+    mp.setenv("_MNE_FAKE_HOME_DIR", str(config_dir))
+    yield
+    mp.undo()
+
+
+@pytest.fixture(autouse=True, scope="session")
 def _isolated_qsettings(tmp_path_factory):
     """Isolate QSettings to a temporary file for the test session."""
     ini_path = tmp_path_factory.mktemp("qsettings") / "mne-qt-browser-test.ini"

--- a/tests/test_pg_specific.py
+++ b/tests/test_pg_specific.py
@@ -113,6 +113,8 @@ def test_annotations_recording_end(raw_orig, pg_backend):
 
 def test_annotations_interactions(raw_orig, pg_backend):
     """Test interactions specific to pyqtgraph-backend."""
+    # Copy to avoid mutating the session-scoped fixture
+    raw_orig = raw_orig.copy()
     # Add test-annotations
     onsets = np.arange(2, 8, 2) + raw_orig.first_time
     durations = np.repeat(1, len(onsets))
@@ -213,6 +215,8 @@ def test_annotations_interactions(raw_orig, pg_backend):
 
 def test_ch_specific_annot(raw_orig, pg_backend):
     """Test plotting channel specific annotations."""
+    # Copy to avoid mutating the session-scoped fixture
+    raw_orig = raw_orig.copy()
     ch_names = ["MEG 0133", "MEG 0142", "MEG 0143", "MEG 0423"]
     annot_onset, annot_dur = 1, 2
     annots = Annotations([annot_onset], [annot_dur], "some_chs", ch_names=[ch_names])


### PR DESCRIPTION
Avoid any possibility of messing with MNE config with a session-scoped fixture, and avoid mutating data from a shared fixture

Found and implemented with Claude Fable 5, and I understand and vouch for all changes