### PR TITLE
FIX: Bug fixes and cleanups in _widgets

### DIFF
--- a/src/mne_qt_browser/_widgets.py
+++ b/src/mne_qt_browser/_widgets.py
@@ -175,8 +175,8 @@ class AnnotationDock(QDockWidget):
         # Update related widgets
         self.weakmain()._setup_annotation_colors()
         self._update_regions_colors()
-        self._update_description_cmbx()
         self.mne.current_description = new_des
+        self._update_description_cmbx()
         self.mne.overview_bar.update_annotations()
 
     def _edit_description_selected(self, new_des):
@@ -233,11 +233,6 @@ class AnnotationDock(QDockWidget):
             # Remove from color mapping
             if rm_description in self.mne.annotation_segment_colors:
                 self.mne.annotation_segment_colors.pop(rm_description)
-
-            # Set first description in combobox to current description
-            if self.description_cmbx.count() > 0:
-                self.description_cmbx.setCurrentIndex(0)
-                self.mne.current_description = self.description_cmbx.currentText()
 
     def _remove_description_dlg(self):
         rm_description = self.description_cmbx.currentText()
@@ -387,11 +382,20 @@ class AnnotationDock(QDockWidget):
             self.stop_bx.setValue(rgn[1])
 
     def _update_description_cmbx(self):
-        self.description_cmbx.clear()
-        descriptions = self.weakmain()._get_annotation_labels()
-        for description in descriptions:
-            self._add_description_to_cmbx(description)
-        self.description_cmbx.setCurrentText(self.mne.current_description)
+        # Rebuilding emits currentIndexChanged (-1 on clear, 0 on the first
+        # addItem), which would clobber mne.current_description through
+        # _description_changed, so block signals and restore the selection
+        # explicitly afterwards
+        with QSignalBlocker(self.description_cmbx):
+            self.description_cmbx.clear()
+            descriptions = self.weakmain()._get_annotation_labels()
+            for description in descriptions:
+                self._add_description_to_cmbx(description)
+            self.description_cmbx.setCurrentText(self.mne.current_description)
+        if self.description_cmbx.count() > 0:
+            # Sync mne.current_description (it may no longer exist, in which
+            # case the combobox settled on the first item) and region z-values
+            self._description_changed(self.description_cmbx.currentIndex())
 
     def _update_regions_colors(self):
         for region in self.mne.regions:
@@ -523,11 +527,8 @@ class ChannelAxis(AxisItem):
         """Customize mouse click events."""
         # Clean up channel texts
         if not self.mne.butterfly:
-            self.ch_texts = {
-                k: v
-                for k, v in self.ch_texts.items()
-                if k in [tr.ch_name for tr in self.mne.traces]
-            }
+            trace_names = {tr.ch_name for tr in self.mne.traces}
+            self.ch_texts = {k: v for k, v in self.ch_texts.items() if k in trace_names}
             # Get channel name from position of channel description
             ypos = event.scenePos().y()
             y_values = list(self.ch_texts.values())
@@ -858,6 +859,12 @@ class OverviewBar(QGraphicsView):
     def update_annotations(self):
         """Update representation of annotations."""
         annotations = self.mne.inst.annotations
+        # Map onsets to annotation indices once (this method runs on every
+        # horizontal scroll, so avoid a full scan per rect below); for
+        # duplicate onsets keep the first index as np.where(...)[0][0] would
+        onset_to_idx = dict()
+        for annot_idx, onset in enumerate(annotations.onset):
+            onset_to_idx.setdefault(onset, annot_idx)
         # Exclude non-visible annotations
         annot_set = set(
             [
@@ -874,7 +881,7 @@ class OverviewBar(QGraphicsView):
         # Add missing onsets
         for add_onset in add_onsets:
             plot_onset = _sync_onset(self.mne.inst, add_onset)
-            annot_idx = np.argwhere(self.mne.inst.annotations.onset == add_onset)[0][0]
+            annot_idx = onset_to_idx[add_onset]
             duration = annotations.duration[annot_idx]
             description = annotations.description[annot_idx]
             color_name = self.mne.annotation_segment_colors[description]
@@ -903,7 +910,7 @@ class OverviewBar(QGraphicsView):
         # Changes
         for edit_onset in self.annotations_rect_dict:
             plot_onset = _sync_onset(self.mne.inst, edit_onset)
-            annot_idx = np.where(annotations.onset == edit_onset)[0][0]
+            annot_idx = onset_to_idx[edit_onset]
             duration = annotations.duration[annot_idx]
             rect_duration = self.annotations_rect_dict[edit_onset]["duration"]
             rect = self.annotations_rect_dict[edit_onset]["rect"]
@@ -1070,8 +1077,11 @@ class OverviewBar(QGraphicsView):
                 top_left = self._mapFromData(epo_t, 0)
                 bottom_right = self._mapFromData(epo_t, len(self.mne.ch_order))
                 epoch_line.setLine(QLineF(top_left, bottom_right))
-            # Resize bad rects
-            for epo_idx, epoch_rect in self.bad_epoch_rect_dict.items():
+            # Resize bad rects (keyed by epoch number, which only matches the
+            # position in boundary_times when no epochs were dropped)
+            selection = self.mne.inst.selection.tolist()
+            for epo_num, epoch_rect in self.bad_epoch_rect_dict.items():
+                epo_idx = selection.index(epo_num)
                 start, stop = self.mne.boundary_times[epo_idx : epo_idx + 2]
                 top_left = self._mapFromData(start, 0)
                 bottom_right = self._mapFromData(stop, len(self.mne.ch_order))
@@ -1274,8 +1284,10 @@ class TimeScrollBar(BaseScrollBar):
             self.setPageStep(self.mne.n_epochs)
             self.setMaximum(len(self.mne.inst) - self.mne.n_epochs)
         else:
-            self.setPageStep(int(self.mne.duration))
             self.step_factor = self.mne.scroll_sensitivity / self.mne.duration
+            # One page (the visible duration) in scrollbar units, so that the
+            # slider length matches the visible fraction of the recording
+            self.setPageStep(int(self.mne.duration * self.step_factor))
             self.setMaximum(int((self.mne.xmax - self.mne.duration) * self.step_factor))
 
     def _update_scroll_sensitivity(self):

--- a/tests/test_pg_specific.py
+++ b/tests/test_pg_specific.py
@@ -1,9 +1,9 @@
 # License: BSD-3-Clause
 # Copyright the MNE Qt Browser contributors.
 
+import mne
 import numpy as np
 import pytest
-import mne
 from mne.utils import check_version
 from numpy.testing import assert_allclose
 from qtpy.QtCore import Qt
@@ -217,7 +217,9 @@ def test_ch_specific_annot(raw_orig, pg_backend):
     """Test plotting channel specific annotations."""
     ch_names = ["MEG 0133", "MEG 0142", "MEG 0143", "MEG 0423"]
     annot_onset, annot_dur = 1, 2
-    annots = mne.Annotations([annot_onset], [annot_dur], "some_chs", ch_names=[ch_names])
+    annots = mne.Annotations(
+        [annot_onset], [annot_dur], "some_chs", ch_names=[ch_names]
+    )
     raw_orig.set_annotations(annots)
 
     ch_names.pop(-1)  # don't plot the last one!

--- a/tests/test_pg_specific.py
+++ b/tests/test_pg_specific.py
@@ -754,3 +754,60 @@ def test_zscore_rgba(raw_orig, pg_backend):
     assert_allclose(zrgba[0], expected)
     # NaN channels are fully transparent
     assert_allclose(zrgba[1], 0)
+
+
+def test_overview_bad_epochs_dropped(raw_orig, pg_backend):
+    """Test bad-epoch rect positions after resize when epochs were dropped."""
+    import mne
+
+    epochs = mne.make_fixed_length_epochs(
+        raw_orig.copy().crop(tmax=20.0), duration=2.0, preload=True
+    )
+    epochs.drop([0, 2])  # make selection non-contiguous
+    fig = epochs.plot()
+    fig.test_mode = True
+    epo_num = epochs.selection[-1]
+    fig.mne.bad_epochs.append(epo_num)
+    overview_bar = fig.mne.overview_bar
+    overview_bar.update_bad_epochs()
+    assert epo_num in overview_bar.bad_epoch_rect_dict
+    # Resizing must reposition the rect via the epoch index, not its number
+    fig.resize(fig.width() + 30, fig.height())
+    QTest.qWait(100)
+    rect = overview_bar.bad_epoch_rect_dict[epo_num].rect()
+    epo_idx = epochs.selection.tolist().index(epo_num)
+    expected_left = overview_bar._mapFromData(fig.mne.boundary_times[epo_idx], 0).x()
+    assert_allclose(rect.left(), expected_left)
+
+
+def test_description_cmbx_preserves_selection(raw_orig, pg_backend):
+    """Test that rebuilding the description combobox keeps the selection."""
+    raw_orig = raw_orig.copy().crop(tmax=5.0)
+    first_time = raw_orig.first_time
+    raw_orig.annotations.append(1 + first_time, 1, "A")
+    raw_orig.annotations.append(3 + first_time, 1, "B")
+    fig = raw_orig.plot()
+    fig.test_mode = True
+    dock = fig.mne.fig_annotation
+    dock.description_cmbx.setCurrentText("B")
+    assert fig.mne.current_description == "B"
+    # Rebuilding emits currentIndexChanged(-1) then (0), which used to clobber
+    # the current description with the first item
+    dock._update_description_cmbx()
+    assert dock.description_cmbx.currentText() == "B"
+    assert fig.mne.current_description == "B"
+    # A no-longer-existing description falls back to the first item
+    fig.mne.current_description = "gone"
+    dock._update_description_cmbx()
+    assert dock.description_cmbx.currentText() == "A"
+    assert fig.mne.current_description == "A"
+
+
+def test_time_scrollbar_page_step(raw_orig, pg_backend):
+    """Test that the scrollbar slider represents the visible fraction."""
+    fig = raw_orig.plot(duration=10.0)
+    fig.test_mode = True
+    ax_hscroll = fig.mne.ax_hscroll
+    # One page in scrollbar units is the visible duration times step_factor
+    assert ax_hscroll.pageStep() == int(fig.mne.duration * ax_hscroll.step_factor)
+    assert ax_hscroll.pageStep() == int(fig.mne.scroll_sensitivity)

--- a/tests/test_pg_specific.py
+++ b/tests/test_pg_specific.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 import pytest
-from mne import Annotations
+import mne
 from mne.utils import check_version
 from numpy.testing import assert_allclose
 from qtpy.QtCore import Qt
@@ -217,7 +217,7 @@ def test_ch_specific_annot(raw_orig, pg_backend):
     """Test plotting channel specific annotations."""
     ch_names = ["MEG 0133", "MEG 0142", "MEG 0143", "MEG 0423"]
     annot_onset, annot_dur = 1, 2
-    annots = Annotations([annot_onset], [annot_dur], "some_chs", ch_names=[ch_names])
+    annots = mne.Annotations([annot_onset], [annot_dur], "some_chs", ch_names=[ch_names])
     raw_orig.set_annotations(annots)
 
     ch_names.pop(-1)  # don't plot the last one!
@@ -760,8 +760,6 @@ def test_zscore_rgba(raw_orig, pg_backend):
 
 def test_overview_bad_epochs_dropped(raw_orig, pg_backend):
     """Test bad-epoch rect positions after resize when epochs were dropped."""
-    import mne
-
     epochs = mne.make_fixed_length_epochs(
         raw_orig.copy().crop(tmax=20.0), duration=2.0, preload=True
     )

--- a/tests/test_pg_specific.py
+++ b/tests/test_pg_specific.py
@@ -3,9 +3,9 @@
 
 import warnings
 
+import mne
 import numpy as np
 import pytest
-import mne
 from mne.utils import check_version
 from numpy.testing import assert_allclose
 from qtpy.QtCore import Qt


### PR DESCRIPTION
Small things:

- Annotation description combobox: rebuilding it clears then repopulates, emitting currentIndexChanged(-1)/(0) which clobbered `mne.current_description`, so block signals during the rebuild
- `bad_epoch_rect_dict` is keyed by epoch number on `main`, which only equals the boundary-times index when no epochs were dropped, so map number to index via `inst.selection` before repositioning
- `setPageStep` in scrollbar units (duration * step_factor) so the slider length reflects the visible fraction
- set-based membership of `ChannelAxis` when pruning ch_texts
- build an onset to index map for `OverviewBar` once instead of scanning annotations.onset per rect on every horizontal scroll

Found and implemented with Claude Fable 5, and I understand and vouch for all changes