### PR TITLE
Use OkLab for dark-theme color conversion

### DIFF
--- a/src/mne_qt_browser/_colors.py
+++ b/src/mne_qt_browser/_colors.py
@@ -10,26 +10,22 @@ from mne.utils import _to_rgb, logger
 from pyqtgraph import mkColor
 from qtpy.QtGui import QColor
 
-_REF_XYZ = (95.047, 100.000, 108.883)  # D65, 2 deg observer
-
 # Mostly chosen from https://matplotlib.org/3.1.0/gallery/color/named_colors.html
 _dark_dict = {
     # 'w' (bgcolor)
     (255, 255, 255): (30, 30, 30),  # Safari's centered info panel background
     # 'k' (eeg, eog, emg, misc, stim, resp, chpi, exci, ias, syst, dipole, gof, ...)
     (0, 0, 0): (255, 255, 255),  # 'w'
-    # 'darkblue' (mag)
-    (0, 0, 139): (173, 216, 230),  # 'lightblue'
-    # 'b' (grad, hbr)
-    (0, 0, 255): (100, 149, 237),  # 'cornflowerblue'
-    # 'steelblue' (ref_meg)
+    # 'darkblue' (mag) and 'b' (grad, hbr) are absent on purpose: the inversion below
+    # handles them with no hue error, where no named pair stayed distinguishable
+    # 'steelblue' (ref_meg), a midtone that would invert to only 1.9:1 contrast
     (70, 130, 180): (176, 196, 222),  # 'lightsteelblue'
     # 'm' (ecg)
     (191, 0, 191): (238, 130, 238),  # 'violet'
     # 'saddlebrown' (seeg)
     (139, 69, 19): (244, 164, 96),  # 'sandybrown'
     # 'seagreen' (dbs)
-    (46, 139, 87): (32, 178, 170),  # 'lightseagreen'
+    (46, 139, 87): (60, 179, 113),  # 'mediumseagreen' (same oklch hue as seagreen)
     # '#AA3377' (hbo), closest to 'mediumvioletred'
     (170, 51, 119): (255, 105, 180),  # 'hotpink'
     # 'lightgray' (bad_color)
@@ -39,73 +35,79 @@ _dark_dict = {
 }
 
 
-def _rgb_to_lab(rgb):
-    # Alternatives include skimage (too heavy, compiled and requires networkx),
-    # PIL.ImageCms (not CIElab, didn't seem to work very well), or
-    # colorspacious (unmaintained), so we'll just go based on the reference
-    # https://www.easyrgb.com/en/math.php
-
-    # sRGB -> XYZ
-    xyz = np.array(rgb, float)  # make a copy
-    assert xyz.shape == (3,), rgb.shape
-    mask = xyz > 0.04045
-    xyz[mask] = ((xyz[mask] + 0.055) / 1.055) ** 2.4
-    xyz[~mask] /= 12.92
-    xyz *= 100
-    xyz = [
-        [0.4124, 0.3576, 0.1805],
-        [0.2126, 0.7152, 0.0722],
-        [0.0193, 0.1192, 0.9505],
-    ] @ xyz
-
-    # XYZ -> CIELab
-    # skimage.color defaults to lluminant='D65', observer='2' so we'll use those same
-    # values
-    lab = xyz / _REF_XYZ
-
-    mask = lab > 0.008856
-    lab[mask] **= 1 / 3
-    lab[~mask] = 7.787 * lab[~mask] + 16 / 116
-    lab = np.array(
-        [
-            (116 * lab[1]) - 16,
-            500 * (lab[0] - lab[1]),
-            200 * (lab[1] - lab[2]),
-        ]
-    )
-
-    return lab
+# Oklab is more perceptually uniform than CIELab, especially in hue. Matrices adapted
+# from https://bottosson.github.io/posts/oklab/ (public domain, or MIT if preferred).
+_M_SRGB_TO_LMS = np.array(
+    [
+        [0.4122214708, 0.5363325363, 0.0514459929],
+        [0.2119034982, 0.6806995451, 0.1073969566],
+        [0.0883024619, 0.2817188376, 0.6299787005],
+    ]
+)
+_M_LMS_TO_OKLAB = np.array(
+    [
+        [0.2104542553, 0.7936177850, -0.0040720468],
+        [1.9779984951, -2.4285922050, 0.4505937099],
+        [0.0259040371, 0.7827717662, -0.8086757660],
+    ]
+)
+# Invert numerically: the published inverses are rounded separately, so hard-coding
+# them would make round-trips inexact
+_M_OKLAB_TO_LMS = np.linalg.inv(_M_LMS_TO_OKLAB)
+_M_LMS_TO_SRGB = np.linalg.inv(_M_SRGB_TO_LMS)
 
 
-def _lab_to_rgb(lab):
+def _rgb_to_oklab(rgb):
+    rgb = np.array(rgb, float)  # make a copy
+    assert rgb.shape == (3,), rgb.shape
+
+    # sRGB -> linear sRGB
+    mask = rgb > 0.04045
+    rgb[mask] = ((rgb[mask] + 0.055) / 1.055) ** 2.4
+    rgb[~mask] /= 12.92
+
+    # linear sRGB -> Oklab
+    return _M_LMS_TO_OKLAB @ np.cbrt(_M_SRGB_TO_LMS @ rgb)
+
+
+def _oklab_to_linear_srgb(lab):
+    return _M_LMS_TO_SRGB @ (_M_OKLAB_TO_LMS @ lab) ** 3
+
+
+def _oklab_to_rgb(lab):
     lab = np.array(lab, float)  # make a copy
     assert lab.shape == (3,), lab.shape
 
-    # CIELab -> XYZ
-    y = (lab[0] + 16) / 116
-    x = lab[1] / 500 + y
-    z = y - lab[2] / 200
-    xyz = np.array([x, y, z], float)
+    rgb = _oklab_to_linear_srgb(lab)
+    eps = 1e-6
+    if rgb.min() < -eps or rgb.max() > 1 + eps:
+        # Out of gamut: clipping RGB would shift hue and lightness, so instead hold
+        # those fixed and search for the largest in-gamut chroma
+        lab[0] = np.clip(lab[0], 0, 1)  # gray axis is in gamut for 0 <= L <= 1
+        lo, hi = 0.0, 1.0
+        for _ in range(30):
+            mid = (lo + hi) / 2
+            test = _oklab_to_linear_srgb(lab * [1.0, mid, mid])
+            if test.min() < -eps or test.max() > 1 + eps:
+                hi = mid
+            else:
+                lo = mid
+        rgb = _oklab_to_linear_srgb(lab * [1.0, lo, lo])
+    np.clip(rgb, 0, 1, out=rgb)
 
-    mask = xyz > 0.20689303442296383  # same as xyz ** 3 > 0.008856
-    xyz[mask] **= 3
-    xyz[~mask] = (xyz[~mask] - 16 / 116) / 7.787
-
-    xyz *= _REF_XYZ
-
-    # XYZ -> sRGB
-    rgb = [
-        [3.2406, -1.5372, -0.4986],
-        [-0.9689, 1.8758, 0.0415],
-        [0.0557, -0.2040, 1.0570],
-    ] @ (xyz / 100)
-
+    # linear sRGB -> sRGB
     mask = rgb > 0.0031308
     rgb[mask] = 1.055 * (rgb[mask] ** (1 / 2.4)) - 0.055
     rgb[~mask] *= 12.92
-    np.clip(rgb, 0, 1, out=rgb)
 
     return rgb
+
+
+# Mirroring alone leaves midtones too close to the background, so clamp to a floor:
+# 0.56 is the lowest oklab lightness clearing 3:1 (WCAG, graphical objects) at every
+# hue. A floor rather than a rescaling, so colors above it keep their spacing and ones
+# differing only in lightness (e.g. 'darkblue' and 'b') stay distinguishable
+_MIN_LIGHTNESS = 0.56
 
 
 def _get_color(color_spec, invert=False):
@@ -145,9 +147,10 @@ def _get_color_cached(*, color_spec, invert):
         else:
             logger.debug(f"Missed {key} from {orig_spec}")
             rgba = np.array(color.getRgbF())
-            lab = _rgb_to_lab(rgba[:3])
-            lab[0] = 100.0 - lab[0]
-            rgba[:3] = _lab_to_rgb(lab)
+            lab = _rgb_to_oklab(rgba[:3])
+            # Mirror the lightness, keeping hue and chroma (a, b) intact
+            lab[0] = max(1.0 - lab[0], _MIN_LIGHTNESS)
+            rgba[:3] = _oklab_to_rgb(lab)
             color.setRgbF(*rgba)
 
     return color

--- a/src/mne_qt_browser/_graphic_items.py
+++ b/src/mne_qt_browser/_graphic_items.py
@@ -26,7 +26,9 @@ from qtpy.QtWidgets import QGraphicsLineItem
 from mne_qt_browser._colors import _get_color
 from mne_qt_browser._utils import _get_channel_scaling, _methpartial, _q_font
 
-_vline_color = (0, 191, 0)
+# Not run through _get_color: this doubles as the VLineLabel fill, whose text is black,
+# so it must stay light in both themes. Clears 3:1 on either background
+_vline_color = (0, 152, 0)
 
 
 def propagate_to_children(method):  # noqa: D103
@@ -775,7 +777,7 @@ class ScaleBar(BaseScaleBar, QGraphicsLineItem):  # noqa: D101
         QGraphicsLineItem.__init__(self)
 
         self.setZValue(1)
-        pen = self.mne.mkPen(color="#AA3377", width=5)
+        pen = self.mne.mkPen(color=_get_color("#AA3377", self.mne.dark), width=5)
         pen.setCapStyle(Qt.FlatCap)
         self.setPen(pen)
         self.update_y_position()
@@ -792,7 +794,7 @@ class ScaleBar(BaseScaleBar, QGraphicsLineItem):  # noqa: D101
 class ScaleBarText(BaseScaleBar, TextItem):  # noqa: D101
     def __init__(self, mne, ch_type):
         BaseScaleBar.__init__(self, mne, ch_type)
-        TextItem.__init__(self, color="#AA3377")
+        TextItem.__init__(self, color=_get_color("#AA3377", self.mne.dark))
 
         self.setFont(_q_font(10))
         self.setZValue(2)  # To draw over RawTraceItems

--- a/src/mne_qt_browser/_pg_figure.py
+++ b/src/mne_qt_browser/_pg_figure.py
@@ -69,7 +69,7 @@ from qtpy.QtWidgets import (
 from scipy.stats import zscore
 
 from mne_qt_browser import _browser_instances
-from mne_qt_browser._colors import _get_color, _rgb_to_lab
+from mne_qt_browser._colors import _get_color, _rgb_to_oklab
 from mne_qt_browser._dialogs import (
     HelpDialog,
     ProjDialog,
@@ -285,7 +285,7 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):  # type: i
         self.mne.mkPen = _methpartial(self._hidpi_mkPen)
 
         bgcolor = self.palette().color(self.backgroundRole()).getRgbF()[:3]
-        self.mne.dark = _rgb_to_lab(bgcolor)[0] < 50
+        self.mne.dark = _rgb_to_oklab(bgcolor)[0] < 0.5
 
         # Prepend our icon search path and set fallback name
         icons_path = f"{Path(__file__).parent}/icons"
@@ -472,7 +472,9 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):  # type: i
 
         # Initialize epochs grid
         if self.mne.is_epochs:
-            grid_pen = self.mne.mkPen(color="k", width=2, style=Qt.DashLine)
+            grid_pen = self.mne.mkPen(
+                color=_get_color("k", self.mne.dark), width=2, style=Qt.DashLine
+            )
             for x_grid in self.mne.boundary_times[1:-1]:
                 grid_line = InfiniteLine(pos=x_grid, pen=grid_pen, movable=False)
                 self.mne.plt.addItem(grid_line)

--- a/src/mne_qt_browser/_widgets.py
+++ b/src/mne_qt_browser/_widgets.py
@@ -782,7 +782,9 @@ class OverviewBar(QGraphicsView):
 
     def update_epoch_lines(self):
         """Update representation of epoch lines."""
-        epoch_line_pen = self.mne.mkPen(color="k", width=1)
+        # Drawn over the channel colors rather than the theme background, and those are
+        # themselves inverted, so this needs the opposite polarity of the theme
+        epoch_line_pen = self.mne.mkPen(color=_get_color("w", self.mne.dark), width=1)
         for t in self.mne.boundary_times[1:-1]:
             top_left = self._mapFromData(t, 0)
             bottom_right = self._mapFromData(t, len(self.mne.ch_order))

--- a/tests/test_pg_specific.py
+++ b/tests/test_pg_specific.py
@@ -11,7 +11,7 @@ from numpy.testing import assert_allclose
 from qtpy.QtCore import Qt
 from qtpy.QtTest import QTest
 
-from mne_qt_browser._colors import _lab_to_rgb, _rgb_to_lab
+from mne_qt_browser._colors import _oklab_to_rgb, _rgb_to_oklab
 from mne_qt_browser._utils import _disconnect
 
 LESS_TIME = "Show fewer time points"
@@ -725,38 +725,38 @@ def test_pg_toolbar_actions(raw_orig, pg_backend):
     assert pg_backend._get_n_figs() == 1
 
 
-# LAB values taken from colorspacious on 2024/06/10
+# Oklab values taken from coloraide on 2026/07/20
 @pytest.mark.parametrize(
     "rgb, lab",
     [
-        [(0, 0, 1), (32.30269787, 79.19228008, -107.86329661)],  # green
-        [(1, 1, 1), (100, 0, 0)],  # white
+        [(0, 0, 1), (0.45201372, -0.03245698, -0.31152817)],  # blue
+        [(1, 1, 1), (1, 0, 0)],  # white
         [(0, 0, 0), (0, 0, 0)],  # black
         # np.random.default_rng(0).uniform(0, 1, (4, 3))
         [
             (0.63696169, 0.26978671, 0.04097352),
-            (41.18329695, 36.11095837, 48.52748511),
+            (0.50652981, 0.09724356, 0.09878626),
         ],
         [
             (0.01652764, 0.81327024, 0.91275558),
-            (76.50078586, -33.20150417, -24.47911354),
+            (0.78437508, -0.11689532, -0.06835410),
         ],
         [
             (0.60663578, 0.72949656, 0.54362499),
-            (72.17250521, -19.45430481, 20.62037424),
+            (0.75317526, -0.05269919, 0.05236921),
         ],
         [
             (0.93507242, 0.81585355, 0.0027385),
-            (83.64455095, -5.45852637, 84.04513029),
+            (0.85722598, -0.02622580, 0.17537609),
         ],
     ],
 )
 def test_color_conversion(rgb, lab):
     """Test color conversions against manually run ones."""
-    our_lab = _rgb_to_lab(rgb)
-    assert_allclose(our_lab, lab, atol=2e-2)
-    rgb_2 = _lab_to_rgb(lab)
-    assert_allclose(rgb, rgb_2, atol=2e-2)
+    our_lab = _rgb_to_oklab(rgb)
+    assert_allclose(our_lab, lab, atol=1e-5)
+    rgb_2 = _oklab_to_rgb(lab)
+    assert_allclose(rgb, rgb_2, atol=1e-5)
 
 
 def test_zscore_rgba(raw_orig, pg_backend):


### PR DESCRIPTION
I recently learned oklab is better than cielab for color conversion, so:

1. Use it (adapting public domain code)
2. Fix some of our contrast and consistency issues using it (for example the mag/grad hues were messed up by using named colors rather than a more straightforward conversion)
3. Fix several places we use a plain color rather than the light/dark-mode sensitive `_get_color`

Investigated and drafted implementation with Claude Fable 5, but iterated heavily to find a good balance with existing code.

The differences are minor (except maybe the epochs divider which is striking, and quite clearly wrong on `main`) but I think it's a clear improvement!

<details>
<summary>MWE</summary>

```python
import sys

import mne
import numpy as np
from scipy.signal import butter, filtfilt

out_fname = sys.argv[1] if len(sys.argv) > 1 else "dark_colors.png"

ch_types = [
    "mag",
    "grad",
    "ref_meg",
    "eeg",
    "eeg",  # will be marked bad
    "eog",
    "ecg",
    "emg",
    "seeg",
    "dbs",
    "ecog",
    "hbo",
    "hbr",
    "resp",
    "chpi",
    "misc",
    "stim",
]
ch_names = [f"{kind.upper()} {ci}" for ci, kind in enumerate(ch_types)]
sfreq = 1000.0
info = mne.create_info(ch_names, sfreq=sfreq, ch_types=ch_types)
rng = np.random.default_rng(0)
data = rng.standard_normal((len(ch_names), int(10 * sfreq)))
b, a = butter(4, 30 / (sfreq / 2))
data = filtfilt(b, a, data, axis=-1)
data /= data.std(axis=-1, keepdims=True)
raw = mne.io.RawArray(data, info)
raw.info["bads"] = [ch_names[4]]
events = np.array([[2000, 0, 1], [5000, 0, 2], [8000, 0, 1]])

mne.viz.set_browser_backend("qt")
fig = raw.plot(
    events=events,
    scalings={ch_type: 8.0 for ch_type in set(ch_types)},
    theme="dark",
    show_scalebars=False,
    block=False,
)
```

</details>

| kind | main | PR |
| -- | -- | -- |
| raw | <img width="2400" height="1800" alt="dark_main" src="https://github.com/user-attachments/assets/271e949b-c889-4e6a-a251-b39821de1f7c" /> | <img width="2400" height="1800" alt="dark_oklch" src="https://github.com/user-attachments/assets/093dafdc-e60b-499a-98b2-afcae225aa2f" /> |
| epochs | <img width="2200" height="1000" alt="dark_epochs_main" src="https://github.com/user-attachments/assets/ac702a24-d924-442e-9717-6d452c383f9c" /> | <img width="2200" height="1000" alt="dark_epochs" src="https://github.com/user-attachments/assets/848a0ef3-034c-4862-8a8b-21736e27f3f3" /> |
