### PR TITLE
FIX: Avoid deprecated QMouseEvent overload

### DIFF
--- a/src/mne_qt_browser/_pg_figure.py
+++ b/src/mne_qt_browser/_pg_figure.py
@@ -42,7 +42,6 @@ from pyqtgraph import (
 from qtpy import API_NAME, QT_VERSION
 from qtpy.QtCore import (
     QEvent,
-    QPointF,
     QSettings,
     QSignalBlocker,
     QThread,
@@ -2452,22 +2451,11 @@ def _close_all():
 
 
 # mouse testing functions adapted from pyqtgraph (pyqtgraph.tests.ui_testing.py)
-def _global_pos(widget, pos):
-    # The QMouseEvent overloads that omit the global position are deprecated, so
-    # always pass it explicitly.
-    return QPointF(widget.mapToGlobal(QPointF(pos).toPoint()))
-
-
 def _mousePress(widget, pos, button, modifier=None):
     if modifier is None:
         modifier = Qt.KeyboardModifier.NoModifier
     event = QMouseEvent(
-        QEvent.Type.MouseButtonPress,
-        QPointF(pos),
-        _global_pos(widget, pos),
-        button,
-        Qt.MouseButton.NoButton,
-        modifier,
+        QEvent.Type.MouseButtonPress, pos, button, Qt.MouseButton.NoButton, modifier
     )
     QApplication.sendEvent(widget, event)
 
@@ -2476,12 +2464,7 @@ def _mouseRelease(widget, pos, button, modifier=None):
     if modifier is None:
         modifier = Qt.KeyboardModifier.NoModifier
     event = QMouseEvent(
-        QEvent.Type.MouseButtonRelease,
-        QPointF(pos),
-        _global_pos(widget, pos),
-        button,
-        Qt.MouseButton.NoButton,
-        modifier,
+        QEvent.Type.MouseButtonRelease, pos, button, Qt.MouseButton.NoButton, modifier
     )
     QApplication.sendEvent(widget, event)
 
@@ -2492,12 +2475,7 @@ def _mouseMove(widget, pos, buttons=None, modifier=None):
     if modifier is None:
         modifier = Qt.KeyboardModifier.NoModifier
     event = QMouseEvent(
-        QEvent.Type.MouseMove,
-        QPointF(pos),
-        _global_pos(widget, pos),
-        Qt.MouseButton.NoButton,
-        buttons,
-        modifier,
+        QEvent.Type.MouseMove, pos, Qt.MouseButton.NoButton, buttons, modifier
     )
     QApplication.sendEvent(widget, event)
 

--- a/src/mne_qt_browser/_pg_figure.py
+++ b/src/mne_qt_browser/_pg_figure.py
@@ -48,7 +48,7 @@ from qtpy.QtCore import (
     QThread,
     Signal,
 )
-from qtpy.QtGui import QIcon, QMouseEvent
+from qtpy.QtGui import QCursor, QIcon, QMouseEvent
 from qtpy.QtTest import QTest
 from qtpy.QtWidgets import (
     QAction,
@@ -2453,15 +2453,16 @@ def _close_all():
 
 # mouse testing functions adapted from pyqtgraph (pyqtgraph.tests.ui_testing.py)
 # The QMouseEvent overloads that omit the global position are deprecated, so pass one
-# explicitly. It must not vary with ``pos``, as pyqtgraph infers drags from screenPos
-# deltas and would then read our synthetic clicks as drags.
+# explicitly. Use exactly what those overloads used, QCursor.pos(): deriving it from
+# ``pos`` (or using a fixed origin) instead reliably segfaults macOS CI in pyqtgraph's
+# curve painting.
 def _mousePress(widget, pos, button, modifier=None):
     if modifier is None:
         modifier = Qt.KeyboardModifier.NoModifier
     event = QMouseEvent(
         QEvent.Type.MouseButtonPress,
         QPointF(pos),
-        QPointF(0, 0),
+        QPointF(QCursor.pos()),
         button,
         Qt.MouseButton.NoButton,
         modifier,
@@ -2475,7 +2476,7 @@ def _mouseRelease(widget, pos, button, modifier=None):
     event = QMouseEvent(
         QEvent.Type.MouseButtonRelease,
         QPointF(pos),
-        QPointF(0, 0),
+        QPointF(QCursor.pos()),
         button,
         Qt.MouseButton.NoButton,
         modifier,
@@ -2491,7 +2492,7 @@ def _mouseMove(widget, pos, buttons=None, modifier=None):
     event = QMouseEvent(
         QEvent.Type.MouseMove,
         QPointF(pos),
-        QPointF(0, 0),
+        QPointF(QCursor.pos()),
         Qt.MouseButton.NoButton,
         buttons,
         modifier,

--- a/src/mne_qt_browser/_pg_figure.py
+++ b/src/mne_qt_browser/_pg_figure.py
@@ -42,6 +42,7 @@ from pyqtgraph import (
 from qtpy import API_NAME, QT_VERSION
 from qtpy.QtCore import (
     QEvent,
+    QPointF,
     QSettings,
     QSignalBlocker,
     QThread,
@@ -2451,11 +2452,22 @@ def _close_all():
 
 
 # mouse testing functions adapted from pyqtgraph (pyqtgraph.tests.ui_testing.py)
+def _global_pos(widget, pos):
+    # The QMouseEvent overloads that omit the global position are deprecated, so
+    # always pass it explicitly.
+    return QPointF(widget.mapToGlobal(QPointF(pos).toPoint()))
+
+
 def _mousePress(widget, pos, button, modifier=None):
     if modifier is None:
         modifier = Qt.KeyboardModifier.NoModifier
     event = QMouseEvent(
-        QEvent.Type.MouseButtonPress, pos, button, Qt.MouseButton.NoButton, modifier
+        QEvent.Type.MouseButtonPress,
+        QPointF(pos),
+        _global_pos(widget, pos),
+        button,
+        Qt.MouseButton.NoButton,
+        modifier,
     )
     QApplication.sendEvent(widget, event)
 
@@ -2464,7 +2476,12 @@ def _mouseRelease(widget, pos, button, modifier=None):
     if modifier is None:
         modifier = Qt.KeyboardModifier.NoModifier
     event = QMouseEvent(
-        QEvent.Type.MouseButtonRelease, pos, button, Qt.MouseButton.NoButton, modifier
+        QEvent.Type.MouseButtonRelease,
+        QPointF(pos),
+        _global_pos(widget, pos),
+        button,
+        Qt.MouseButton.NoButton,
+        modifier,
     )
     QApplication.sendEvent(widget, event)
 
@@ -2475,7 +2492,12 @@ def _mouseMove(widget, pos, buttons=None, modifier=None):
     if modifier is None:
         modifier = Qt.KeyboardModifier.NoModifier
     event = QMouseEvent(
-        QEvent.Type.MouseMove, pos, Qt.MouseButton.NoButton, buttons, modifier
+        QEvent.Type.MouseMove,
+        QPointF(pos),
+        _global_pos(widget, pos),
+        Qt.MouseButton.NoButton,
+        buttons,
+        modifier,
     )
     QApplication.sendEvent(widget, event)
 

--- a/src/mne_qt_browser/_pg_figure.py
+++ b/src/mne_qt_browser/_pg_figure.py
@@ -42,6 +42,7 @@ from pyqtgraph import (
 from qtpy import API_NAME, QT_VERSION
 from qtpy.QtCore import (
     QEvent,
+    QPointF,
     QSettings,
     QSignalBlocker,
     QThread,
@@ -2451,11 +2452,19 @@ def _close_all():
 
 
 # mouse testing functions adapted from pyqtgraph (pyqtgraph.tests.ui_testing.py)
+# The QMouseEvent overloads that omit the global position are deprecated, so pass one
+# explicitly. It must not vary with ``pos``, as pyqtgraph infers drags from screenPos
+# deltas and would then read our synthetic clicks as drags.
 def _mousePress(widget, pos, button, modifier=None):
     if modifier is None:
         modifier = Qt.KeyboardModifier.NoModifier
     event = QMouseEvent(
-        QEvent.Type.MouseButtonPress, pos, button, Qt.MouseButton.NoButton, modifier
+        QEvent.Type.MouseButtonPress,
+        QPointF(pos),
+        QPointF(0, 0),
+        button,
+        Qt.MouseButton.NoButton,
+        modifier,
     )
     QApplication.sendEvent(widget, event)
 
@@ -2464,7 +2473,12 @@ def _mouseRelease(widget, pos, button, modifier=None):
     if modifier is None:
         modifier = Qt.KeyboardModifier.NoModifier
     event = QMouseEvent(
-        QEvent.Type.MouseButtonRelease, pos, button, Qt.MouseButton.NoButton, modifier
+        QEvent.Type.MouseButtonRelease,
+        QPointF(pos),
+        QPointF(0, 0),
+        button,
+        Qt.MouseButton.NoButton,
+        modifier,
     )
     QApplication.sendEvent(widget, event)
 
@@ -2475,7 +2489,12 @@ def _mouseMove(widget, pos, buttons=None, modifier=None):
     if modifier is None:
         modifier = Qt.KeyboardModifier.NoModifier
     event = QMouseEvent(
-        QEvent.Type.MouseMove, pos, Qt.MouseButton.NoButton, buttons, modifier
+        QEvent.Type.MouseMove,
+        QPointF(pos),
+        QPointF(0, 0),
+        Qt.MouseButton.NoButton,
+        buttons,
+        modifier,
     )
     QApplication.sendEvent(widget, event)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,8 +115,6 @@ def pytest_configure(config):
     matplotlib.rcParams["figure.raise_window"] = False
     warning_lines = r"""
     error::
-    # PySide6
-    ignore:Function.*is marked as deprecated, please check the .*:DeprecationWarning
     """
     for warning_line in warning_lines.split("\n"):
         warning_line = warning_line.strip()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,10 +115,6 @@ def pytest_configure(config):
     matplotlib.rcParams["figure.raise_window"] = False
     warning_lines = r"""
     error::
-    # PySide6
-    ignore:Enum value .* is marked as deprecated:DeprecationWarning
-    ignore:Function.*is marked as deprecated, please check the .*:DeprecationWarning
-    ignore:Failed to disconnect.*:RuntimeWarning
     """
     for warning_line in warning_lines.split("\n"):
         warning_line = warning_line.strip()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,6 +115,8 @@ def pytest_configure(config):
     matplotlib.rcParams["figure.raise_window"] = False
     warning_lines = r"""
     error::
+    # PySide6
+    ignore:Function.*is marked as deprecated, please check the .*:DeprecationWarning
     """
     for warning_line in warning_lines.split("\n"):
         warning_line = warning_line.strip()

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -8,20 +8,26 @@ from time import perf_counter
 import mne
 import numpy as np
 import pytest
+from mne.utils import check_version
 from qtpy.QtCore import QTimer
 
 from mne_qt_browser._pg_figure import _methpartial
 from mne_qt_browser.figure import MNEQtBrowser
 
-try:
-    import OpenGL  # noqa
-except Exception as exc:
-    has_gl = False
-    reason = str(exc)
+# pyqtgraph 0.14 dropped the PyOpenGL requirement for OpenGL rendering, so it is only
+# needed on older versions (see the check in _pg_figure.py).
+if check_version("pyqtgraph", "0.14"):
+    has_gl, reason = True, ""
 else:
-    has_gl = True
-    reason = ""
-gl_mark = pytest.mark.skipif(not has_gl, reason=f"Requires PyOpengl (got {reason})")
+    try:
+        import OpenGL  # noqa
+    except Exception as exc:
+        has_gl, reason = False, str(exc)
+    else:
+        has_gl, reason = True, ""
+gl_mark = pytest.mark.skipif(
+    not has_gl, reason=f"pyqtgraph < 0.14 requires PyOpenGL (got {reason})"
+)
 
 
 class _Benchmark:


### PR DESCRIPTION
In bug-squashing mode, take care of a little deprecation warning we can avoid hitting, and get rid of OpenGL testing cruft. Trivial stuff here and CIs are the real gate so I'll mark for merge-when-green. Claude Opus 4.8 helped draft the changes and I edited.

Closes #152