### PR TITLE
Fix precompute

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,7 @@ jobs:
             mne: maint/1.8  # released 2024/08/18
             python: '3.10'
             name: old
+            allow_skip: '^.*mne < 1\.10 pads the shown range.*$'
           - os: ubuntu
             mne: main
             python: '3.14'
@@ -78,8 +79,10 @@ jobs:
       - run: mne sys_info
       - run: pytest -m pgtest --cov=mne_qt_browser --cov-report=xml mne-python/mne/report mne-python/mne/viz
         name: Run MNE-Tests
-      - run: pytest --error-for-skips tests/test_pg_specific.py --cov-report=xml --cov-append
+      - run: pytest tests/test_pg_specific.py --cov-report=xml --cov-append
         name: Run pyqtgraph-specific tests
+        env:
+          MNE_TEST_ALLOW_SKIP: ${{ matrix.allow_skip || '^$' }}
       # These are slow on macOS, so skip them
       - run: pytest tests/test_speed.py --cov-report=xml --cov-append
         name: Run benchmarks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ tests = [
   "pytest-timeout",
   "scikit-learn",
   "pytest-harvest",
-  "pytest-error-for-skips",
   "sphinx-gallery",
   "refleak >=0.2.1",
 ]

--- a/src/mne_qt_browser/_graphic_items.py
+++ b/src/mne_qt_browser/_graphic_items.py
@@ -567,12 +567,7 @@ class DataTrace(PlotCurveItem):
 
     def _apply_transform(self):
         transform = QTransform()
-        if self.mne.data_precomputed:
-            transform.scale(
-                1.0, self.mne.scale_factor / self.mne.scalings[self.ch_type]
-            )
-        else:
-            transform.scale(1.0, self.mne.scale_factor)
+        transform.scale(1.0, self.mne.scale_factor)
         self.setTransform(transform)
 
     @propagate_to_children

--- a/src/mne_qt_browser/_pg_figure.py
+++ b/src/mne_qt_browser/_pg_figure.py
@@ -177,6 +177,11 @@ class LoadThread(QThread):
             # Load raw
             else:
                 data_chunk, times_chunk = browser._load_data(start, stop)
+                if stop is not None:
+                    # mne < 1.10 pads with two extra samples, which would be
+                    # duplicated into global_data at every chunk boundary
+                    data_chunk = data_chunk[:, : stop - start]
+                    times_chunk = times_chunk[: stop - start]
                 data_chunks.append(data_chunk)
                 times_chunks.append(times_chunk)
 

--- a/src/mne_qt_browser/_pg_figure.py
+++ b/src/mne_qt_browser/_pg_figure.py
@@ -195,20 +195,19 @@ class LoadThread(QThread):
         if self.isInterruptionRequested():
             return
         picks = self.mne.ch_order
-        # Deactivate remove_dc because DC is removed for the visible range instead
-        stashed_remove_dc = self.mne.remove_dc
-        self.mne.remove_dc = False
-        data = browser._process_data(data, 0, data.shape[-1], picks, self)
-        # The GUI thread may have toggled remove_dc while we were processing;
-        # only restore the stashed value if it did not (so we never clobber a
-        # user toggle)
-        if self.mne.remove_dc is False:
-            self.mne.remove_dc = stashed_remove_dc
-
-        ch_type_ordered = self.mne.ch_types[self.mne.ch_order]
-        for chii in range(data.shape[0]):
-            ch_type = ch_type_ordered[chii]
-            data[chii, :] *= self.mne.scalings[ch_type]
+        # This is _process_data (plus the sign inversion of our override of it)
+        # minus the two steps that depend on the shown range, which _update_data
+        # does per view instead: DC removal, and scaling each channel into its
+        # 1-vertical-unit slot (stim channels are divided by their maximum over
+        # the shown range, and self.mne.scalings can change after precomputing)
+        if self.mne.projector is not None:
+            self.processText.emit("Applying Projectors...")
+            data = self.mne.projector @ data
+        data = data[picks]
+        if self.mne.filter_coefs is not None:
+            self.processText.emit("Apply Filter...")
+            browser._apply_filter(data, 0, data.shape[-1], picks)
+        data *= -1  # displayed from the top on an inverted y-axis
 
         if self.isInterruptionRequested():
             return
@@ -1606,12 +1605,33 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):  # type: i
 
         return data
 
+    def _get_display_norms(self, picks, data):
+        """Get the divisors that scale each channel into its 1-unit slot.
+
+        This mirrors the scaling step of ``BrowserBase._process_data``, which the
+        precompute path has to do itself for the shown range (see ``_update_data``).
+        ``data`` is that range, sign-inverted and unscaled.
+        """
+        this_names = self.mne.ch_names[picks]
+        this_types = self.mne.ch_types[picks]
+        norms = np.array([self.mne.scalings[t] for t in this_types], float)
+        stims = this_types == "stim"
+        norms[stims] = -data[stims].min(axis=-1)  # data is inverted
+        # Whitened channels are already in units of standard deviation, unless
+        # they are bad (those are not whitened)
+        norms[
+            np.isin(this_names, self.mne.whitened_ch_names)
+            & np.isin(this_names, self.mne.info["bads"], invert=True)
+        ] = self.mne.scalings["whitened"]
+        norms[norms == 0] = 1
+        return 2 * norms
+
     def _update_data(self):
         if self.mne.data_precomputed:
             # get start/stop samples
             start, stop = self._get_start_stop()
             self.mne.times = self.mne.global_times[start:stop]
-            self.mne.data = self.mne.global_data[:, start:stop]
+            data = self.mne.global_data[:, start:stop]
 
             # remove DC locally but keep track of the offset
             if self.mne.remove_dc:
@@ -1623,11 +1643,18 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):  # type: i
                     warnings.filterwarnings(
                         "ignore", "Mean of empty slice", RuntimeWarning
                     )
-                    dc_offset = np.nanmean(self.mne.data, axis=1, keepdims=True)
-                self.mne.zero_line_offset = -dc_offset[:, 0]
-                self.mne.data = self.mne.data - dc_offset
+                    dc_offset = np.nanmean(data, axis=1, keepdims=True)
+                data = data - dc_offset
             else:
-                self.mne.zero_line_offset = None
+                dc_offset = None
+
+            # Scale here rather than in LoadThread so that stim channels and
+            # self.mne.scalings changes behave as they do without precomputation
+            norms = self._get_display_norms(self.mne.ch_order, data)[:, np.newaxis]
+            self.mne.data = data / norms
+            self.mne.zero_line_offset = (
+                None if dc_offset is None else -(dc_offset / norms)[:, 0]
+            )
         else:
             # While data is not precomputed get data only from shown range and process
             # only those

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 # Copyright the MNE Qt Browser contributors.
 
 import os
+import re
 from pathlib import Path
 
 import matplotlib
@@ -27,6 +28,43 @@ def pytest_runtest_makereport(item, call):
     outcome = yield
     rep = outcome.get_result()
     item.stash.setdefault(_phase_report_key, {})[rep.when] = rep
+
+
+# Unset means "allow every skip". Set it to e.g. "^$" to turn all skips into errors,
+# or to a pattern matching the reasons that are expected on this configuration.
+MNE_TEST_ALLOW_SKIP = os.getenv("MNE_TEST_ALLOW_SKIP", None)
+_valid_skips_re = re.compile(MNE_TEST_ALLOW_SKIP or ".*", re.DOTALL)
+
+
+def pytest_report_header(config):
+    """Add the allowed skips to the pytest run header."""
+    if MNE_TEST_ALLOW_SKIP is None:
+        return []
+    return [f"Allowed skips: {MNE_TEST_ALLOW_SKIP!r}"]
+
+
+def pytest_report_teststatus(report, config):
+    """Turn unexpected skips into errors (adapted from mne-python's conftest)."""
+    # Both report types matter: CollectReport covers skipif marks, TestReport covers
+    # skips raised from a test body (e.g. importorskip)
+    if MNE_TEST_ALLOW_SKIP is None or report.outcome != "skipped":
+        return
+    if isinstance(report.longrepr, tuple):
+        file, lineno, reason = report.longrepr
+    else:
+        file, lineno, reason = "<unknown>", 1, str(report.longrepr)
+    if _valid_skips_re.match(reason):
+        return
+    # xfails are not skips, but are reported as such (by mark, or by traceback)
+    if (
+        getattr(report, "keywords", {}).get("xfail", False)
+        or " pytest.xfail( " in reason
+    ):
+        return
+    reason = reason.removeprefix("Skipped: ")
+    report.longrepr = f"{file}:{lineno}: UNEXPECTED SKIP: {reason!r}"
+    report.outcome = "error" if isinstance(report, pytest.TestReport) else "failed"
+    return report.outcome, report.outcome[0].upper(), "UNEXPECTED SKIP"
 
 
 def _test_passed(request):

--- a/tests/test_pg_specific.py
+++ b/tests/test_pg_specific.py
@@ -912,15 +912,27 @@ def _traces_drawn(fig):
     for trace in fig.mne.traces:
         traces = [trace] + list(getattr(trace, "child_traces", []))
         # Child traces (epochs) each draw one color and NaN out the rest
-        drawn = np.full(len(trace.xData) + 1, np.nan)
+        drawn = np.full(len(trace.xData), np.nan)
         for this in traces:
             y = this.transform().m22() * np.asarray(this.yData)
-            drawn[:-1][np.isfinite(y)] = y[np.isfinite(y)]
-        drawn[-1] = trace._true_zero_ypos() - trace.ypos  # zero_line_offset
+            drawn[np.isfinite(y)] = y[np.isfinite(y)]
+        if _HAS_ZERO_LINE_OFFSET:
+            zero = trace._true_zero_ypos() - trace.ypos
+            drawn = np.concatenate([drawn, [zero]])
         out[trace.ch_name] = drawn
     return out
 
 
+# BrowserBase only tracks the DC offset of the shown range (and thus places the zero
+# line at the true zero) as of mne 1.13
+_HAS_ZERO_LINE_OFFSET = check_version("mne", "1.13")
+
+
+@pytest.mark.skipif(
+    not check_version("mne", "1.10"),
+    # ... which the precompute path never did, so the two modes cannot match there
+    reason="mne < 1.10 pads the shown range with two extra samples",
+)
 @pytest.mark.parametrize("clipping", ("transparent", "clamp", None))
 def test_precompute_matches_on_the_fly(raw_orig, pg_backend, clipping):
     """Test that precomputed data is displayed like data processed on the fly."""

--- a/tests/test_pg_specific.py
+++ b/tests/test_pg_specific.py
@@ -7,7 +7,7 @@ import mne
 import numpy as np
 import pytest
 from mne.utils import check_version
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_array_equal
 from qtpy.QtCore import Qt
 from qtpy.QtTest import QTest
 
@@ -894,3 +894,72 @@ def test_get_onset_idx_float_tolerance(raw_orig, pg_backend):
     # Each annotation still resolves to its own index despite sub-sample drift
     assert fig._get_onset_idx(3.0 + drift) == 1  # "B"
     assert fig._get_onset_idx(1.0 - drift) == 0  # "A"
+
+
+def _wait_precompute(fig):
+    for _ in range(600):
+        if fig.mne.data_precomputed:
+            return
+        QTest.qWait(100)
+    raise AssertionError("Precomputation did not finish")
+
+
+def _traces_drawn(fig):
+    """Get what each trace draws plus its zero line, relative to its own baseline."""
+    # Relative to the baseline (rather than in data coordinates) so that assert_allclose
+    # is not dominated by ypos, which is the same in both modes anyway
+    out = dict()
+    for trace in fig.mne.traces:
+        traces = [trace] + list(getattr(trace, "child_traces", []))
+        # Child traces (epochs) each draw one color and NaN out the rest
+        drawn = np.full(len(trace.xData) + 1, np.nan)
+        for this in traces:
+            y = this.transform().m22() * np.asarray(this.yData)
+            drawn[:-1][np.isfinite(y)] = y[np.isfinite(y)]
+        drawn[-1] = trace._true_zero_ypos() - trace.ypos  # zero_line_offset
+        out[trace.ch_name] = drawn
+    return out
+
+
+@pytest.mark.parametrize("clipping", ("transparent", "clamp", None))
+def test_precompute_matches_on_the_fly(raw_orig, pg_backend, clipping):
+    """Test that precomputed data is displayed like data processed on the fly."""
+    # A window that has stim events but whose stim maxima differ from the maxima over
+    # the whole recording (gh-270), and all channel types visible
+    raw_orig = raw_orig.copy().crop(tmax=10.0)
+    kwargs = dict(
+        clipping=clipping,
+        n_channels=len(raw_orig.ch_names),
+        duration=2.0,
+        start=3.0,
+    )
+    drawn = dict()
+    for precompute in (False, True):
+        fig = raw_orig.plot(precompute=precompute, **kwargs)
+        fig.test_mode = True
+        if precompute:
+            _wait_precompute(fig)
+        drawn[precompute] = [_traces_drawn(fig)]
+        # Each of these has at some point been broken by precomputation only
+        for action in (
+            lambda: fig._toggle_all_projs(),  # projectors
+            lambda: fig._click_ch_name(0, 0),  # bad channel (changes projector)
+            lambda: fig._fake_keypress("="),  # scale_factor
+            lambda: fig.mne.scalings.__setitem__("grad", 1e-10) or fig._redraw(),
+            lambda: fig._fake_keypress("d"),  # DC removal
+            lambda: fig._fake_keypress("right"),  # scroll
+        ):
+            action()
+            QTest.qWait(50)
+            if precompute:
+                _wait_precompute(fig)
+            drawn[precompute].append(_traces_drawn(fig))
+        fig.close()
+
+    for on_the_fly, precomputed in zip(drawn[False], drawn[True]):
+        assert set(on_the_fly) == set(precomputed)
+        for ch_name, expected in on_the_fly.items():
+            got = precomputed[ch_name]
+            # Clipping must kick in for the same samples in both modes
+            assert_array_equal(np.isnan(got), np.isnan(expected), err_msg=ch_name)
+            assert_allclose(got, expected, atol=1e-10, err_msg=ch_name)


### PR DESCRIPTION
Closes #270

Worked with Claude Fable 5 to finally fix the precompute bug, complete with a unit test that the two modes match 🚀 

Fix turned out to be pretty simple by making the precompute path more like the non-precompute path in terms of how scalings are handled. I consider this a trivial fix at the end of the day so I'll self-mark for merge-when-green!