### PR TITLE
FIX: Butterfly mode scale bars and spacing (#276)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,16 @@ jobs:
         with:
           qt: true
       - run: mne sys_info
-      - run: pytest -m pgtest --cov=mne_qt_browser --cov-report=xml mne-python/mne/report mne-python/mne/viz
+      - run: |
+          # On MNE < 1.13 (i.e. not main) test_plotting_scalebars still asserts the
+          # pre-#276 butterfly scalebar geometry (bars spanning a full y-unit), which
+          # the fix here intentionally changes. The updated test only lives on MNE
+          # main (via the companion PR), so deselect it on the older release branches.
+          deselect=()
+          if [[ "${{ matrix.mne }}" != "main" ]]; then
+            deselect=(--deselect mne-python/mne/viz/tests/test_raw.py::test_plotting_scalebars)
+          fi
+          pytest -m pgtest --cov=mne_qt_browser --cov-report=xml "${deselect[@]}" mne-python/mne/report mne-python/mne/viz
         name: Run MNE-Tests
       - run: pytest tests/test_pg_specific.py --cov-report=xml --cov-append
         name: Run pyqtgraph-specific tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          repository: 'mne-tools/mne-python'
+          repository: mne-tools/mne-python
           path: mne-python
           ref: ${{ matrix.mne }}
       - uses: actions/setup-python@v7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,17 +48,15 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          # TEMP: pull larsoner/mne-python@scale for MNE main until the companion
-          # MNE-Python PR merges; other matrix entries use the upstream branches
-          repository: ${{ (matrix.mne == 'main' && 'larsoner/mne-python') || 'mne-tools/mne-python' }}
+          repository: 'mne-tools/mne-python'
           path: mne-python
-          ref: ${{ (matrix.mne == 'main' && 'scale') || matrix.mne }}
+          ref: ${{ matrix.mne }}
       - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python }}
       - run: |
           python -m pip install --upgrade pip
-          test "$(git branch --show-current)" == "${{ (matrix.mne == 'main' && 'scale') || matrix.mne }}"
+          test "$(git branch --show-current)" == "${{ matrix.mne }}"
           python -m pip install -e .
         name: Install MNE-Python
         working-directory: mne-python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,12 +83,13 @@ jobs:
           # On MNE < 1.13 (i.e. not main) test_plotting_scalebars still asserts the
           # pre-#276 butterfly scalebar geometry (bars spanning a full y-unit), which
           # the fix here intentionally changes. The updated test only lives on MNE
-          # main (via the companion PR), so deselect it on the older release branches.
-          deselect=()
+          # main (via the companion PR), so skip it on the older release branches.
+          # (-k by name rather than --deselect, whose nodeid is rootdir-relative here.)
+          filter=()
           if [[ "${{ matrix.mne }}" != "main" ]]; then
-            deselect=(--deselect mne-python/mne/viz/tests/test_raw.py::test_plotting_scalebars)
+            filter=(-k "not test_plotting_scalebars")
           fi
-          pytest -m pgtest --cov=mne_qt_browser --cov-report=xml "${deselect[@]}" mne-python/mne/report mne-python/mne/viz
+          pytest -m pgtest --cov=mne_qt_browser --cov-report=xml "${filter[@]}" mne-python/mne/report mne-python/mne/viz
         name: Run MNE-Tests
       - run: pytest tests/test_pg_specific.py --cov-report=xml --cov-append
         name: Run pyqtgraph-specific tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,9 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          repository: larsoner/mne-python
+          # TEMP: pull larsoner/mne-python@scale for MNE main until the companion
+          # MNE-Python PR merges; other matrix entries use the upstream branches
+          repository: ${{ (matrix.mne == 'main' && 'larsoner/mne-python') || 'mne-tools/mne-python' }}
           path: mne-python
           ref: ${{ (matrix.mne == 'main' && 'scale') || matrix.mne }}
       - uses: actions/setup-python@v7
@@ -56,7 +58,7 @@ jobs:
           python-version: ${{ matrix.python }}
       - run: |
           python -m pip install --upgrade pip
-          test "$(git branch --show-current)" == "${{ matrix.mne }}"
+          test "$(git branch --show-current)" == "${{ (matrix.mne == 'main' && 'scale') || matrix.mne }}"
           python -m pip install -e .
         name: Install MNE-Python
         working-directory: mne-python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,9 +48,9 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          repository: mne-tools/mne-python
+          repository: larsoner/mne-python
           path: mne-python
-          ref: ${{ matrix.mne }}
+          ref: ${{ (matrix.mne == 'main' && 'scale') || matrix.mne }}
       - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python }}

--- a/src/mne_qt_browser/_graphic_items.py
+++ b/src/mne_qt_browser/_graphic_items.py
@@ -30,6 +30,15 @@ from mne_qt_browser._utils import _get_channel_scaling, _q_font
 # so it must stay light in both themes. Clears 3:1 on either background
 _vline_color = (0, 152, 0)
 
+# Z-values of the items in the trace plot (higher values are drawn on top). In butterfly
+# mode good traces get an additional offset (up to _Z_TRACE_MAX) so that the channel
+# types shown at the top of the plot are drawn over the ones below them.
+_Z_BAD_TRACE = 0
+_Z_TRACE = 1
+_Z_TRACE_MAX = 100
+_Z_SCALEBAR = 101
+_Z_SCALEBAR_TEXT = 102
+
 
 def propagate_to_children(method):  # noqa: D103
     @functools.wraps(method)
@@ -404,8 +413,8 @@ class DataTrace(PlotCurveItem):
         # Set clickable with small area around trace to make clicking easier
         self.setClickable(True, 12)
 
-        # Set default z-value to 1 to be before other items in scene
-        self.setZValue(1)
+        # Draw before annotations, events and zero lines (which sit at zero)
+        self.setZValue(_Z_TRACE)
 
         # General attributes
         # The ch_idx is the index of the channel represented by this trace in the
@@ -516,13 +525,23 @@ class DataTrace(PlotCurveItem):
         # Raw/ICA
         else:
             if self.isbad:
-                self.setZValue(0)
+                self.setZValue(_Z_BAD_TRACE)
                 self.color = self.mne.ch_color_bad
             else:
-                self.setZValue(1)
+                self.setZValue(self._get_zvalue())
                 self.color = self.mne.ch_color_ref[self.ch_name]
 
         self.setPen(self.mne.mkPen(_get_color(self.color, self.mne.dark)))
+
+    def _get_zvalue(self):
+        """Get the z-value of a good trace."""
+        if not self.mne.butterfly or self.mne.fig_selection is not None:
+            return _Z_TRACE
+        # Channel types plotted higher up come first in the data order, so they should
+        # be drawn over the ones below them
+        order = self.mne.butterfly_type_order
+        zvalue = _Z_TRACE + len(order) - order.index(self.ch_type)
+        return min(zvalue, _Z_TRACE_MAX)
 
     @propagate_to_children
     def update_range_idx(self):  # noqa: D401
@@ -741,7 +760,10 @@ class DataTrace(PlotCurveItem):
 
     def get_ydata(self):
         """Get ydata for testing."""
-        return self.yData + self.ypos
+        # self.yData is drawn through the item transform (which applies scale_factor,
+        # halved in butterfly mode), then offset by ypos -- mirror that here so the
+        # returned values match what is shown on screen
+        return self.transform().m22() * self.yData + self.ypos
 
 
 class EventLine(InfiniteLine):
@@ -771,14 +793,17 @@ class ScaleBar(BaseScaleBar, QGraphicsLineItem):  # noqa: D101
         BaseScaleBar.__init__(self, mne, ch_type)
         QGraphicsLineItem.__init__(self)
 
-        self.setZValue(1)
+        self.setZValue(_Z_SCALEBAR)
         pen = self.mne.mkPen(color=_get_color("#AA3377", self.mne.dark), width=5)
         pen.setCapStyle(Qt.FlatCap)
         self.setPen(pen)
         self.update_y_position()
 
     def _set_position(self, x, y):
-        self.setLine(QLineF(x, y - 0.5, x, y + 0.5))
+        # In butterfly mode traces are drawn at half amplitude, so the bar spans
+        # half a y-unit instead of a full one (like the matplotlib backend)
+        half = 0.25 if self.mne.butterfly else 0.5
+        self.setLine(QLineF(x, y - half, x, y + half))
 
     def get_ydata(self):
         """Get y-data for tests."""
@@ -792,7 +817,7 @@ class ScaleBarText(BaseScaleBar, TextItem):  # noqa: D101
         TextItem.__init__(self, color=_get_color("#AA3377", self.mne.dark))
 
         self.setFont(_q_font(10))
-        self.setZValue(2)  # To draw over RawTraceItems
+        self.setZValue(_Z_SCALEBAR_TEXT)  # To draw over RawTraceItems
 
         self.update_value()
         self.update_y_position()

--- a/src/mne_qt_browser/_pg_figure.py
+++ b/src/mne_qt_browser/_pg_figure.py
@@ -2325,17 +2325,22 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):  # type: i
         self.vscroll(step)
 
     def _click_ch_name(self, ch_index, button):
-        self.mne.channel_axis.repaint()
-        # Wait because channel axis may need time
-        # (came up with test_epochs::test_plot_epochs_clicks)
-        QTest.qWait(100)
-        if not self.mne.butterfly:
-            ch_name = str(self.mne.ch_names[self.mne.picks[ch_index]])
-            xrange, yrange = self.mne.channel_axis.ch_texts[ch_name]
-            x = np.mean(xrange)
-            y = np.mean(yrange)
-
-            self._fake_click((x, y), fig=self.mne.view, button=button, xform="none")
+        if self.mne.butterfly:
+            return
+        ch_name = str(self.mne.ch_names[self.mne.picks[ch_index]])
+        # channel_axis.ch_texts is populated lazily when the axis repaints, which the
+        # event loop only does once its queued layout/view-range updates and the
+        # deferred paint have been delivered. A single fixed wait flaked on macOS CI
+        # (gh-276, test_epochs::test_plot_epochs_clicks), so poll until it appears.
+        for _ in range(100):
+            self.mne.channel_axis.repaint()
+            QTest.qWait(10)
+            if ch_name in self.mne.channel_axis.ch_texts:
+                break
+        xrange, yrange = self.mne.channel_axis.ch_texts[ch_name]
+        x = np.mean(xrange)
+        y = np.mean(yrange)
+        self._fake_click((x, y), fig=self.mne.view, button=button, xform="none")
 
     def _resize_by_factor(self, factor):
         pass

--- a/src/mne_qt_browser/_pg_figure.py
+++ b/src/mne_qt_browser/_pg_figure.py
@@ -325,6 +325,8 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):  # type: i
         self.mne.traces = list()
         # Scale factor
         self.mne.scale_factor = 1
+        # Factor of the scale factor that is due to butterfly mode
+        self.mne.butterfly_scale = 1.0
         # DPI
         screen = QApplication.primaryScreen()
         self.mne.dpi = screen.physicalDotsPerInch()
@@ -1956,27 +1958,38 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):  # type: i
 
     def _set_butterfly(self, butterfly):
         self.mne.butterfly = butterfly
+        # Butterfly mode draws the traces at half amplitude (like the matplotlib
+        # backend). Track what we applied so that repeated calls don't compound.
+        butterfly_scale = 0.5 if butterfly else 1.0
+        if butterfly_scale != self.mne.butterfly_scale:
+            self.mne.scale_factor *= butterfly_scale / self.mne.butterfly_scale
+            self.mne.butterfly_scale = butterfly_scale
+            for line in self.mne.traces:
+                line.update_scale()
         self._update_picks()
         self._update_data()
 
+        # Each row (channel type or selection) gets exactly one y-unit, so that
+        # the first and last rows are half a unit away from the edges.
         if butterfly and self.mne.fig_selection is not None:
             self.mne.selection_ypos_dict.clear()
             selections_dict = self._make_butterfly_selections_dict()
             for idx, picks in enumerate(selections_dict.values()):
                 for pick in picks:
                     self.mne.selection_ypos_dict[pick] = idx + 1
-            ymax = len(selections_dict) + 1
-            self.mne.ymax = ymax
-            self.mne.plt.setLimits(yMax=ymax)
-            self.mne.plt.setYRange(0, ymax, padding=0)
+            n_rows = len(selections_dict)
         elif butterfly:
-            ymax = len(self.mne.butterfly_type_order) + 1
-            self.mne.ymax = ymax
-            self.mne.plt.setLimits(yMax=ymax)
-            self.mne.plt.setYRange(0, ymax, padding=0)
+            n_rows = len(self.mne.butterfly_type_order)
+        else:
+            n_rows = None
+
+        if butterfly:
+            self.mne.ymax = n_rows + 0.5
+            self.mne.plt.setLimits(yMin=0.5, yMax=self.mne.ymax)
+            self.mne.plt.setYRange(0.5, self.mne.ymax, padding=0)
         else:
             self.mne.ymax = len(self.mne.ch_order) + 1
-            self.mne.plt.setLimits(yMax=self.mne.ymax)
+            self.mne.plt.setLimits(yMin=0, yMax=self.mne.ymax)
             self.mne.plt.setYRange(
                 self.mne.ch_start,
                 self.mne.ch_start + self.mne.n_channels + 1,
@@ -2001,6 +2014,10 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):  # type: i
             trace.update_ypos()
 
         self._draw_traces()
+
+        # Scalebar height and value both depend on butterfly mode
+        self._update_scalebar_values()
+        self._update_scalebar_y_positions()
 
         self._update_ch_spinbox_values()
 
@@ -2579,3 +2596,8 @@ def _init_browser(**kwargs):
     browser = MNEQtBrowser(**kwargs)
 
     return browser
+
+
+# TODO VERSION: signal to MNE-Python to use the newer scalebar checks. Can be removed
+# once MNE-Python requires mne-qt-browser >= 0.7.6
+_SCALEBARS_FIXED = True

--- a/src/mne_qt_browser/_widgets.py
+++ b/src/mne_qt_browser/_widgets.py
@@ -478,7 +478,9 @@ class ChannelAxis(AxisItem):
     def tickValues(self, minVal, maxVal, size):
         """Customize creation of axis values from visible axis range."""
         minVal, maxVal = sorted((minVal, maxVal))
-        values = list(range(round(minVal) + 1, round(maxVal)))
+        # One tick per integer y-position strictly inside the visible range (channels
+        # start at y=1, and in butterfly mode the range ends on a half unit)
+        values = list(range(int(np.floor(minVal)) + 1, int(np.ceil(maxVal))))
         tick_values = [(1, values)]
         return tick_values
 
@@ -961,9 +963,10 @@ class OverviewBar(QGraphicsView):
     def update_viewrange(self):
         """Update representation of viewrange."""
         if self.mne.butterfly:
+            # all channels are shown, and the overview bar is scaled by channel count
             top_left = self._mapFromData(self.mne.t_start, 0)
             bottom_right = self._mapFromData(
-                self.mne.t_start + self.mne.duration, self.mne.ymax
+                self.mne.t_start + self.mne.duration, len(self.mne.ch_order)
             )
         else:
             top_left = self._mapFromData(self.mne.t_start, self.mne.ch_start)

--- a/tests/test_pg_specific.py
+++ b/tests/test_pg_specific.py
@@ -975,3 +975,46 @@ def test_precompute_matches_on_the_fly(raw_orig, pg_backend, clipping):
             # Clipping must kick in for the same samples in both modes
             assert_array_equal(np.isnan(got), np.isnan(expected), err_msg=ch_name)
             assert_allclose(got, expected, atol=1e-10, err_msg=ch_name)
+
+
+def test_butterfly_scalebars(raw_orig, pg_backend):
+    """Test that butterfly mode matches the matplotlib backend (gh-276)."""
+    raw_orig = raw_orig.copy().crop(tmax=5.0)
+    fig = raw_orig.plot()
+    fig.test_mode = True
+    ch_types = fig.mne.butterfly_type_order
+    assert ch_types == ["grad", "mag", "eeg", "eog", "stim"]
+    normal_texts = fig._get_scale_bar_texts()
+    normal_scale_factor = fig.mne.scale_factor
+
+    def _check_butterfly():
+        # Each channel type gets exactly one y-unit, without extra space at the
+        # top and bottom of the plot
+        assert_allclose(fig.mne.viewbox.viewRange()[1], [0.5, len(ch_types) + 0.5])
+        # Traces are drawn at half amplitude, so the bars span half a unit ...
+        for ci, ch_type in enumerate(ch_types, 1):
+            if ch_type not in fig.mne.scalebars:  # stim has no scalebar
+                continue
+            assert_allclose(
+                fig.mne.scalebars[ch_type].get_ydata(), [ci - 0.25, ci + 0.25]
+            )
+        # ... which keeps the values identical to non-butterfly mode
+        assert fig._get_scale_bar_texts() == normal_texts
+        # Channel types plotted higher up are drawn over the ones below them
+        zvalues = {tr.ch_type: tr.zValue() for tr in fig.mne.traces if not tr.isbad}
+        assert [zvalues[ch_type] for ch_type in ch_types] == sorted(
+            zvalues.values(), reverse=True
+        )
+
+    fig._fake_keypress("b")
+    _check_butterfly()
+
+    # Toggling back and forth is a no-op for the scale factor
+    fig._fake_keypress("b")
+    assert fig.mne.scale_factor == normal_scale_factor
+    assert fig._get_scale_bar_texts() == normal_texts
+
+    # Starting out in butterfly mode gives the same result
+    fig = raw_orig.plot(butterfly=True)
+    fig.test_mode = True
+    _check_butterfly()


### PR DESCRIPTION
Closes #276.

Draft until we see this and MNE-Python green. Then:

- [x] switch this back to using MNE `main`
- [x] switch the MNE-Python PR back to using mne-qt-browser `main`
- [x] merge MNE-Python branch (should be green)
- [x] restart CIs here, should come back green
- [x] merge here

Visual confirmation (synthetic data using sawtooth wave with peak-to-peak that should match the scalebars):

| - | main | PR |
| -- | -- | -- |
| mpl | <img width="921" height="887" alt="image" src="https://github.com/user-attachments/assets/85cd83fb-3ec2-4050-918f-bd3d8ad69415" /> | <img width="922" height="887" alt="image" src="https://github.com/user-attachments/assets/aa71fae5-7ff4-4bdb-b87a-c9eb8c937fba" />| 
| qt | <img width="887" height="855" alt="image" src="https://github.com/user-attachments/assets/802df4cd-f01f-4c30-8c4e-12c6b2c0605f" /> | <img width="887" height="855" alt="image" src="https://github.com/user-attachments/assets/3dc02a76-dc5b-4bba-b437-fa692cda60f8" /> |


<details>
<summary>MWE</summary>

```
import numpy as np
from scipy.signal import sawtooth

import mne

sfreq = 100.0
period = 50  # samples; 10 whole periods over 5 s keeps the wave exactly zero-mean
n = 500
ph = (np.arange(n) % period) / period
triangle = 1 - 2 * np.abs(2 * ph - 1)
peak_to_peak = dict(grad=400e-13, mag=1000e-15, eeg=20e-6)
n_per_type = 2  # a couple of channels per type, as in any real recording
ch_types, ch_names, data = [], [], []
for ct, pp in peak_to_peak.items():
    for i in range(n_per_type):
        ch_types.append(ct)
        ch_names.append(f"{ct}{i}")
        data.append(pp / 2 * np.roll(triangle, i * period // n_per_type // 2))
info = mne.create_info(ch_names, sfreq, ch_types=ch_types)
raw = mne.io.RawArray(np.array(data), info)
scalings = {ct: pp / 2 for ct, pp in peak_to_peak.items()}
with mne.viz.use_browser_backend("matplotlib"):
    raw.plot(scalings=scalings, clipping=None)
with mne.viz.use_browser_backend("qt"):
    raw.plot(scalings=scalings, clipping=None)
# press "b" in both
```

</details>