### PR TITLE
Fix sensitivity for butterfly mode

### DIFF
--- a/src/mne_qt_browser/_dialogs.py
+++ b/src/mne_qt_browser/_dialogs.py
@@ -459,10 +459,11 @@ class SettingsDialog(_BaseDialog):
             new_value = self.dpi_spinbox.value()
             self.mne.dpi = new_value
             mon_units = self.current_monitor_units
-            dpr = screen.devicePixelRatio()
 
             with QSignalBlocker(self.mon_height_spinbox):
-                mon_height_inch = (px_height / dpr) / new_value
+                # px_height is already in the device-independent pixels that
+                # physicalDotsPerInch (and hence mne.dpi) counts, so no devicePixelRatio
+                mon_height_inch = px_height / new_value
                 self.mon_height_spinbox.setValue(
                     _convert_physical_units(
                         mon_height_inch, from_unit="inch", to_unit=mon_units
@@ -470,7 +471,7 @@ class SettingsDialog(_BaseDialog):
                 )
 
             with QSignalBlocker(self.mon_width_spinbox):
-                mon_width_inch = (px_width / dpr) / new_value
+                mon_width_inch = px_width / new_value
                 self.mon_width_spinbox.setValue(
                     _convert_physical_units(
                         mon_width_inch, from_unit="inch", to_unit=mon_units
@@ -541,12 +542,13 @@ class SettingsDialog(_BaseDialog):
                 if new_value == 0:
                     self.mne.scalings[ch_type] = 1e-12
                 else:
-                    scaler = 1 if self.mne.butterfly else 2
+                    # Inverse of _calc_chan_type_to_physical (the 2 is the one in
+                    # _get_y_unit_scaling)
                     self.mne.scalings[ch_type] = (
                         new_value
                         * self.mne.scale_factor
                         * _calc_data_unit_to_physical(self, units=current_units)
-                        / (scaler * self.mne.unit_scalings[ch_type])
+                        / (2 * self.mne.unit_scalings[ch_type])
                     )
 
                 with QSignalBlocker(self.ch_scaling_spinboxes[ch_type]):

--- a/src/mne_qt_browser/_dialogs.py
+++ b/src/mne_qt_browser/_dialogs.py
@@ -395,44 +395,22 @@ class SettingsDialog(_BaseDialog):
         screen = _screen(self)
         px_height = screen.size().height()
         px_width = screen.size().width()
-        if dim == "height":
-            new_ht_val = self.mon_height_spinbox.value()
-
-            # Get new dpi
-            mon_units = self.current_monitor_units
-            mon_height_inch = _convert_physical_units(
-                new_ht_val, from_unit=mon_units, to_unit="inch"
+        if dim in ("height", "width"):
+            # Pixels are square, so either dimension on its own pins down the DPI, and
+            # the other one then follows from it
+            if dim == "height":
+                px, value = px_height, self.mon_height_spinbox.value()
+            else:
+                px, value = px_width, self.mon_width_spinbox.value()
+            self.mne.dpi = px / _convert_physical_units(
+                value, from_unit=self.current_monitor_units, to_unit="inch"
             )
-            dpi = px_height / mon_height_inch
-
-            # Find new width of monitor
-            with QSignalBlocker(self.mon_width_spinbox):
-                mon_width = self.mne.aspect_ratio * new_ht_val
-                self.mon_width_spinbox.setValue(mon_width)
-
-            self.mne.dpi = dpi
-            self.dpi_spinbox.setValue(self.mne.dpi)
-
+            self._show_monitor_size(px_height, px_width)
             self._update_spinbox_values(ch_type="all", source="unit_change")
 
-        elif dim == "width":
-            new_wd_value = self.mon_width_spinbox.value()
-
-            # Get new dpi
-            mon_units = self.current_monitor_units
-            mon_width_inch = _convert_physical_units(
-                new_wd_value, from_unit=mon_units, to_unit="inch"
-            )
-            dpi = px_width / mon_width_inch
-
-            # Find new height of monitor
-            with QSignalBlocker(self.mon_height_spinbox):
-                mon_height = new_wd_value / self.mne.aspect_ratio
-                self.mon_height_spinbox.setValue(mon_height)
-
-            self.mne.dpi = dpi
-            self.dpi_spinbox.setValue(self.mne.dpi)
-
+        elif dim == "dpi":
+            self.mne.dpi = self.dpi_spinbox.value()
+            self._show_monitor_size(px_height, px_width)
             self._update_spinbox_values(ch_type="all", source="unit_change")
 
         elif dim == "unit_change":
@@ -455,56 +433,38 @@ class SettingsDialog(_BaseDialog):
 
             self.current_monitor_units = new_units
 
-        elif dim == "dpi":
-            new_value = self.dpi_spinbox.value()
-            self.mne.dpi = new_value
-            mon_units = self.current_monitor_units
-
-            with QSignalBlocker(self.mon_height_spinbox):
-                # px_height is already in the device-independent pixels that
-                # physicalDotsPerInch (and hence mne.dpi) counts, so no devicePixelRatio
-                mon_height_inch = px_height / new_value
-                self.mon_height_spinbox.setValue(
-                    _convert_physical_units(
-                        mon_height_inch, from_unit="inch", to_unit=mon_units
-                    )
-                )
-
-            with QSignalBlocker(self.mon_width_spinbox):
-                mon_width_inch = px_width / new_value
-                self.mon_width_spinbox.setValue(
-                    _convert_physical_units(
-                        mon_width_inch, from_unit="inch", to_unit=mon_units
-                    )
-                )
-
-            self._update_spinbox_values(ch_type="all", source="unit_change")
-
         else:
             raise ValueError(f"Unknown dimension: {dim}")
 
+    def _show_monitor_size(self, px_height, px_width):
+        """Show the monitor size implied by self.mne.dpi, and the DPI itself."""
+        for spinbox, px in (
+            (self.mon_height_spinbox, px_height),
+            (self.mon_width_spinbox, px_width),
+        ):
+            with QSignalBlocker(spinbox):
+                # px is already in the device-independent pixels that
+                # physicalDotsPerInch counts, so no devicePixelRatio here
+                spinbox.setValue(
+                    _convert_physical_units(
+                        px / self.mne.dpi,
+                        from_unit="inch",
+                        to_unit=self.current_monitor_units,
+                    )
+                )
+        with QSignalBlocker(self.dpi_spinbox):
+            self.dpi_spinbox.setValue(self.mne.dpi)
+
     def _reset_monitor_spinboxes(self):
         """Reset monitor spinboxes to expected values."""
-        mon_units = self.mon_units_cmbx.currentText()
-
-        # Get the screen size
         screen = _screen(self)
-        height_mm = screen.physicalSize().height()
-        width_mm = screen.physicalSize().width()
-
-        height_mon_units = _convert_physical_units(
-            height_mm, from_unit="mm", to_unit=mon_units
-        )
-        width_mon_units = _convert_physical_units(
-            width_mm, from_unit="mm", to_unit=mon_units
-        )
-
+        # physicalDotsPerInch averages the X and Y densities, which are two estimates
+        # of the same thing since pixels are square. Derive the sizes shown from that
+        # average rather than from physicalSize, which the two disagree about whenever
+        # it is rounded or, on a virtual display, invented -- otherwise re-entering a
+        # shown size would silently change the DPI.
         self.mne.dpi = screen.physicalDotsPerInch()
-
-        # Set the spinbox values as such
-        self.mon_height_spinbox.setValue(height_mon_units)
-        self.mon_width_spinbox.setValue(width_mon_units)
-        self.dpi_spinbox.setValue(self.mne.dpi)
+        self._show_monitor_size(screen.size().height(), screen.size().width())
 
         # Update sensitivity spinboxes
         self._update_spinbox_values(ch_type="all", source="unit_change")

--- a/src/mne_qt_browser/_graphic_items.py
+++ b/src/mne_qt_browser/_graphic_items.py
@@ -24,7 +24,7 @@ from qtpy.QtGui import QTransform
 from qtpy.QtWidgets import QGraphicsLineItem
 
 from mne_qt_browser._colors import _get_color
-from mne_qt_browser._utils import _get_channel_scaling, _q_font
+from mne_qt_browser._utils import _butterfly_scale, _get_channel_scaling, _q_font
 
 # Not run through _get_color: this doubles as the VLineLabel fill, whose text is black,
 # so it must stay light in both themes. Clears 3:1 on either background
@@ -800,9 +800,7 @@ class ScaleBar(BaseScaleBar, QGraphicsLineItem):  # noqa: D101
         self.update_y_position()
 
     def _set_position(self, x, y):
-        # In butterfly mode traces are drawn at half amplitude, so the bar spans
-        # half a y-unit instead of a full one (like the matplotlib backend)
-        half = 0.25 if self.mne.butterfly else 0.5
+        half = _butterfly_scale(self.mne) / 2
         self.setLine(QLineF(x, y - half, x, y + half))
 
     def get_ydata(self):

--- a/src/mne_qt_browser/_pg_figure.py
+++ b/src/mne_qt_browser/_pg_figure.py
@@ -89,6 +89,7 @@ from mne_qt_browser._graphic_items import (
 )
 from mne_qt_browser._utils import (
     DATA_CH_TYPES_ORDER,
+    _butterfly_scale,
     _disconnect,
     _get_channel_scaling,
     _methpartial,
@@ -1958,9 +1959,8 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):  # type: i
 
     def _set_butterfly(self, butterfly):
         self.mne.butterfly = butterfly
-        # Butterfly mode draws the traces at half amplitude (like the matplotlib
-        # backend). Track what we applied so that repeated calls don't compound.
-        butterfly_scale = 0.5 if butterfly else 1.0
+        # Track what we applied so that repeated calls don't compound
+        butterfly_scale = _butterfly_scale(self.mne)
         if butterfly_scale != self.mne.butterfly_scale:
             self.mne.scale_factor *= butterfly_scale / self.mne.butterfly_scale
             self.mne.butterfly_scale = butterfly_scale

--- a/src/mne_qt_browser/_pg_figure.py
+++ b/src/mne_qt_browser/_pg_figure.py
@@ -328,12 +328,9 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):  # type: i
         self.mne.scale_factor = 1
         # Factor of the scale factor that is due to butterfly mode
         self.mne.butterfly_scale = 1.0
-        # DPI
+        # DPI (the X/Y average, see SettingsDialog._reset_monitor_spinboxes)
         screen = QApplication.primaryScreen()
         self.mne.dpi = screen.physicalDotsPerInch()
-
-        # Aspect ratio
-        self.mne.aspect_ratio = screen.geometry().width() / screen.geometry().height()
         # Stores channel types for butterfly mode
         self.mne.butterfly_type_order = [
             tp for tp in DATA_CH_TYPES_ORDER if tp in self.mne.ch_types

--- a/src/mne_qt_browser/_utils.py
+++ b/src/mne_qt_browser/_utils.py
@@ -26,6 +26,7 @@ qsettings_params = {
 
 _unit_per_inch = dict(mm=25.4, cm=2.54, inch=1.0)
 
+
 # Butterfly mode draws traces at half amplitude (like the matplotlib backend, gh-276),
 # which equally shortens the scalebar and the value it stands for
 BUTTERFLY_SCALE = 0.5
@@ -140,7 +141,6 @@ def _calc_data_unit_to_physical(widget, units="mm"):
         return 0
 
     # Get the screen DPI
-    # px_per_in = QApplication.primaryScreen().logicalDotsPerInch()
     px_per_in = widget.mne.dpi
 
     # Convert to inches

--- a/src/mne_qt_browser/_utils.py
+++ b/src/mne_qt_browser/_utils.py
@@ -26,6 +26,15 @@ qsettings_params = {
 
 _unit_per_inch = dict(mm=25.4, cm=2.54, inch=1.0)
 
+# Butterfly mode draws traces at half amplitude (like the matplotlib backend, gh-276),
+# which equally shortens the scalebar and the value it stands for
+BUTTERFLY_SCALE = 0.5
+
+
+def _butterfly_scale(mne):
+    """Get the factor butterfly mode shrinks traces and scalebars by."""
+    return BUTTERFLY_SCALE if mne.butterfly else 1.0
+
 
 def _disconnect(sig, *, allow_error=False):
     try:
@@ -108,7 +117,9 @@ def _unique_ordered_ch_types(mne):
 
 def _calc_chan_type_to_physical(widget, ch_type, units="mm"):
     """Convert data to physical units."""
-    return _get_channel_scaling(widget, ch_type) / _calc_data_unit_to_physical(
+    # Butterfly mode needs no correction here: a shorter scalebar standing for a
+    # proportionally smaller value cancels out, leaving only its scale_factor effect
+    return _get_y_unit_scaling(widget, ch_type) / _calc_data_unit_to_physical(
         widget, units=units
     )
 
@@ -159,13 +170,17 @@ def _convert_physical_units(value, from_unit=None, to_unit=None):
     return converted_value
 
 
-def _get_channel_scaling(widget, ch_type):
-    """Get channel scaling."""
-    scaler = 1 if widget.mne.butterfly else 2
-    inv_norm = (
-        scaler
+def _get_y_unit_scaling(widget, ch_type):
+    """Get the data value spanned by one y-unit (i.e., by one channel's row)."""
+    # data are normalized to +/-0.5 of a y-unit (see _get_display_norms), hence the 2
+    return (
+        2
         * widget.mne.scalings[ch_type]
         * widget.mne.unit_scalings[ch_type]
         / widget.mne.scale_factor
     )
-    return inv_norm
+
+
+def _get_channel_scaling(widget, ch_type):
+    """Get the value a scalebar stands for."""
+    return _butterfly_scale(widget.mne) * _get_y_unit_scaling(widget, ch_type)

--- a/tests/test_pg_specific.py
+++ b/tests/test_pg_specific.py
@@ -489,17 +489,30 @@ def test_pg_settings_dialog(raw_orig, pg_backend):
     orig_sens = ch_sens_spinbox.value()
     fig.mne.fig_settings.mon_height_spinbox.setValue(orig_mon_height / 2)
     QTest.keyPress(fig.mne.fig_settings.mon_height_spinbox.lineEdit(), Qt.Key_Return)
-    fig.mne.fig_settings.mon_width_spinbox.setValue(orig_mon_width / 2)
-    QTest.keyPress(fig.mne.fig_settings.mon_width_spinbox.lineEdit(), Qt.Key_Return)
+    assert_allclose(
+        fig.mne.fig_settings.dpi_spinbox.value(), orig_mon_dpi * 2, rtol=1e-3
+    )
+    assert_allclose(
+        fig.mne.fig_settings.mon_width_spinbox.value(), orig_mon_width / 2, rtol=1e-3
+    )
     assert ch_sens_spinbox.value() != orig_sens
 
-    # Re-entering the shown DPI is a no-op, i.e. it is the inverse of entering a
-    # monitor size
-    fig.mne.fig_settings._reset_monitor_spinboxes()
-    QTest.keyPress(fig.mne.fig_settings.dpi_spinbox.lineEdit(), Qt.Key_Return)
-    assert_allclose(fig.mne.fig_settings.mon_height_spinbox.value(), orig_mon_height)
-    assert_allclose(fig.mne.fig_settings.mon_width_spinbox.value(), orig_mon_width)
-    assert_allclose(fig.mne.fig_settings.dpi_spinbox.value(), orig_mon_dpi)
+    # Reset leaves height, width and DPI mutually consistent -- pixels are square, even
+    # where the physical size Qt reports is not -- so re-entering any one of them is a
+    # no-op. rtol covers the spinboxes rounding to two decimals.
+    for box in ("mon_height_spinbox", "mon_width_spinbox", "dpi_spinbox"):
+        fig.mne.fig_settings._reset_monitor_spinboxes()
+        QTest.keyPress(getattr(fig.mne.fig_settings, box).lineEdit(), Qt.Key_Return)
+        assert_allclose(
+            fig.mne.fig_settings.mon_height_spinbox.value(), orig_mon_height, rtol=1e-3
+        )
+        assert_allclose(
+            fig.mne.fig_settings.mon_width_spinbox.value(), orig_mon_width, rtol=1e-3
+        )
+        assert_allclose(
+            fig.mne.fig_settings.dpi_spinbox.value(), orig_mon_dpi, rtol=1e-3
+        )
+        assert_allclose(ch_sens_spinbox.value(), orig_sens, rtol=1e-3)
 
     # Monitor settings reset button works
     fig.mne.fig_settings._reset_monitor_spinboxes()

--- a/tests/test_pg_specific.py
+++ b/tests/test_pg_specific.py
@@ -13,7 +13,7 @@ from qtpy.QtCore import Qt
 from qtpy.QtTest import QTest
 
 from mne_qt_browser._colors import _oklab_to_rgb, _rgb_to_oklab
-from mne_qt_browser._utils import _disconnect
+from mne_qt_browser._utils import _calc_data_unit_to_physical, _disconnect
 
 LESS_TIME = "Show fewer time points"
 MORE_TIME = "Show more time points"
@@ -492,6 +492,14 @@ def test_pg_settings_dialog(raw_orig, pg_backend):
     fig.mne.fig_settings.mon_width_spinbox.setValue(orig_mon_width / 2)
     QTest.keyPress(fig.mne.fig_settings.mon_width_spinbox.lineEdit(), Qt.Key_Return)
     assert ch_sens_spinbox.value() != orig_sens
+
+    # Re-entering the shown DPI is a no-op, i.e. it is the inverse of entering a
+    # monitor size
+    fig.mne.fig_settings._reset_monitor_spinboxes()
+    QTest.keyPress(fig.mne.fig_settings.dpi_spinbox.lineEdit(), Qt.Key_Return)
+    assert_allclose(fig.mne.fig_settings.mon_height_spinbox.value(), orig_mon_height)
+    assert_allclose(fig.mne.fig_settings.mon_width_spinbox.value(), orig_mon_width)
+    assert_allclose(fig.mne.fig_settings.dpi_spinbox.value(), orig_mon_dpi)
 
     # Monitor settings reset button works
     fig.mne.fig_settings._reset_monitor_spinboxes()
@@ -996,3 +1004,34 @@ def test_butterfly_scalebars(raw_orig, pg_backend):
     fig = raw_orig.plot(butterfly=True)
     fig.test_mode = True
     _check_butterfly()
+
+
+def test_sensitivity_matches_scalebar(raw_orig, pg_backend):
+    """Test that the reported sensitivity is the one actually drawn on screen."""
+    fig = raw_orig.copy().crop(tmax=5.0).plot(splash=False)
+    fig.test_mode = True
+    QTest.qWaitForWindowExposed(fig)
+    fig._fake_click_on_toolbar_action("Settings", wait_after=0)
+    ch_type = "grad"  # the only type shown in the default (non-butterfly) view
+    assert set(fig.mne.ch_types[fig.mne.picks]) == {ch_type}
+
+    def _check_sensitivity():
+        # The scalebar spans a known number of y-units and is labeled with the
+        # value it represents, so it pins down the true units-per-mm on screen
+        y1, y2 = fig.mne.scalebars[ch_type].get_ydata()
+        mm = abs(y2 - y1) * _calc_data_unit_to_physical(fig, units="mm")
+        value = float(fig.mne.scalebar_texts[ch_type].toPlainText().split()[0])
+        spinbox = fig.mne.fig_settings.ch_sensitivity_spinboxes[ch_type]
+        # atol covers the spinbox rounding to one decimal
+        assert_allclose(spinbox.value(), value / mm, rtol=0.01, atol=0.05)
+
+    _check_sensitivity()
+    fig._fake_keypress("b")
+    _check_sensitivity()
+
+    # Entering a sensitivity gives that sensitivity, in butterfly mode too
+    for butterfly in (True, False):
+        assert fig.mne.butterfly is butterfly
+        fig.mne.fig_settings.ch_sensitivity_spinboxes[ch_type].setValue(12.5)
+        _check_sensitivity()
+        fig._fake_keypress("b")


### PR DESCRIPTION
Doing the recent butterfly scale work made me wonder if the sensitivity stuff worked in butterfly mode... it had bugs. Now this:

<details>
<summary>Test code</summary>

```
"""Draw a trace whose peak-to-peak is exactly 1 inch, to check against a real ruler.

A +/-127 uV square wave has a peak-to-peak of 254 uV, so at a sensitivity of
10 uV/mm it must span 254 / 10 = 25.4 mm = exactly 1 inch on screen.
"""

import mne
import numpy as np
from qtpy.QtCore import QPointF
from qtpy.QtWidgets import QApplication

TARGET_INCHES = 1.0
AMPLITUDE_UV = 127.0  # peak-to-peak is twice this, i.e. 254 uV
SENSITIVITY = 2 * AMPLITUDE_UV / (TARGET_INCHES * 25.4)  # uV/mm -> exactly 10.0

mne.set_log_level("warning")
mne.viz.set_browser_backend("qt")

# A square wave puts the peak-to-peak between two flat lines, which is what you measure
sfreq, n_sec = 100.0, 10.0
times = np.arange(n_sec * sfreq) / sfreq
data = AMPLITUDE_UV * 1e-6 * np.sign(np.sin(2 * np.pi * 0.5 * times))
raw = mne.io.RawArray(data[np.newaxis], mne.create_info(["EEG 001"], sfreq, "eeg"))

fig = raw.plot(
    n_channels=1,
    duration=n_sec,
    clipping=None,
    remove_dc=False,
    show=False,
    splash=False,
)
fig.show()

# Open Settings and dial in the sensitivity
fig._fake_click_on_toolbar_action("Settings", wait_after=100)
dlg = fig.mne.fig_settings
dlg.physical_units_cmbx.setCurrentText("/ mm")
dlg.ch_sensitivity_spinboxes["eeg"].setValue(SENSITIVITY)

# What Qt believes about the monitor -- if this is wrong, so is everything below.
# Correct it in the dialog's "Monitor Size" box and the trace resizes to match.
screen = fig.screen()
print(
    f"Qt thinks this screen is {screen.physicalSize().width():.1f} x "
    f"{screen.physicalSize().height():.1f} mm "
    f"({screen.physicalSize().width() / 25.4:.2f} x "
    f"{screen.physicalSize().height() / 25.4:.2f} inches) at {fig.mne.dpi:.1f} dpi.\n"
    "Check that against the spec sheet; fix it in 'Monitor Size' if it is wrong."
)

# Independent check: ask pyqtgraph where the trace actually lands on screen
vb = fig.mne.viewbox
px_per_y = abs(
    vb.mapViewToScene(QPointF(0.0, 1.0)).y() - vb.mapViewToScene(QPointF(0.0, 0.0)).y()
)
y_data = fig.mne.traces[0].get_ydata()  # already in y-units, as drawn
p2p_in = (np.nanmax(y_data) - np.nanmin(y_data)) * px_per_y / fig.mne.dpi
print(f"\nsensitivity set to {SENSITIVITY} uV/mm -> predicted {p2p_in:.4f} inches")
print(
    f"\n>>> Hold a ruler to the screen: the flat top and bottom of the square wave\n"
    f"    should be exactly {TARGET_INCHES} inch apart.\n"
    ">>> Press 'b' (butterfly): the trace must NOT change size, and Sensitivity must\n"
    "    keep reading 10.0. (It wrongly read 5.0 before the butterfly fix -- with one\n"
    "    channel the halved amplitude and the halved y-range cancel on screen.)\n"
    ">>> Resizing the window DOES rescale the trace, since the scalings are what is\n"
    "    held fixed; re-enter 10.0 in Sensitivity to get back to 1 inch."
)

QApplication.instance().exec()
```

</details>

Shows a 1-inch-tall signal in butterfly and normal mode. This is a pretty straightforward change (drafted by Opus 5 and reviewed by me) along with a DRY of the butterfly scaling, and the proof is in the MWE so I'll mark for merge-when-green.